### PR TITLE
[fix/YH-659]-Fixed a bug with clicking on the page header on mobile devices

### DIFF
--- a/src/shared/ui/AppLogo/AppLogo.module.css
+++ b/src/shared/ui/AppLogo/AppLogo.module.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  width: 100%;
+  width: auto;
   transition: padding-left 0.5s ease-in-out;
 }
 


### PR DESCRIPTION
Исправил баг с кликом на заголовок страницы на мобильных устройствах.  
**Причина:** Селектору `.home-link` ссылки на главную страницу была задана фиксированная ширина, изменил на автоматическую ширину.
