### PR TITLE
[fix/YH-679]-Fixed a bug with the width of the filter block on the platform

### DIFF
--- a/src/pages/interview/QuestionsPage/ui/QuestionsPage/QuestionsPage.module.css
+++ b/src/pages/interview/QuestionsPage/ui/QuestionsPage/QuestionsPage.module.css
@@ -49,6 +49,7 @@
   flex-shrink: 0;
   flex-direction: column;
   gap: 20px;
+  width: 360px;
 }
 
 .search {


### PR DESCRIPTION
В стилях компонента ```QuestionsPage``` селектора ```.additional-info-wrapper``` добавил свойство ширины как по макету 360px. 