### PR TITLE
YH-792: Refactoring: Styles

### DIFF
--- a/src/app/layouts/MainLayout/ui/MainLayout.module.css
+++ b/src/app/layouts/MainLayout/ui/MainLayout.module.css
@@ -50,3 +50,9 @@
     flex-direction: column;
   }
 }
+
+@media (width <= 767px) { 
+  .main {
+    padding: 20px 10px;
+  }
+}

--- a/src/pages/interview/InterviewQuizPage/ui/InterviewQuizPage.module.css
+++ b/src/pages/interview/InterviewQuizPage/ui/InterviewQuizPage.module.css
@@ -84,9 +84,9 @@
   }
 }
 
-@media (width <= 768px) {
+@media (width <= 767px) {
   .container > div {
-    padding: 16px;
+    padding: 20px 10px;
   }
 
   .question {

--- a/src/pages/interview/InterviewQuizPage/ui/InterviewQuizPage.tsx
+++ b/src/pages/interview/InterviewQuizPage/ui/InterviewQuizPage.tsx
@@ -80,7 +80,7 @@ const InterviewQuizPage = () => {
 	};
 
 	return (
-		<Flex direction="column" gap="24" className={styles.container}>
+		<Flex direction="column" gap="20" className={styles.container}>
 			<Card withOutsideShadow>
 				<div className={styles['progress-bar']}>
 					<p className={styles['progress-bar-title']}>{t(InterviewQuiz.TITLE)}</p>
@@ -95,7 +95,7 @@ const InterviewQuizPage = () => {
 				</div>
 			</Card>
 			<Card withOutsideShadow>
-				<Flex direction="column" gap="24" className={styles.question}>
+				<Flex direction="column" gap="20" className={styles.question}>
 					<QuestionNavPanel
 						goToNextSlide={onRightSlide}
 						goToPrevSlide={onPrevSlide}

--- a/src/pages/interview/InterviewStatisticsPage/ui/InterviewStatisticsPage.module.css
+++ b/src/pages/interview/InterviewStatisticsPage/ui/InterviewStatisticsPage.module.css
@@ -27,7 +27,6 @@
 @media (width < 1024px) {
   .container {
     flex-direction: column;
-    gap: 24px;
   }
 
   .history {
@@ -39,14 +38,10 @@
   } 
 }
 
-@media (width < 768px) {
+@media (width <= 767px) {
   .quizzes,
   .progress {
-    padding: 16px;
+    padding: 20px 10px;
     min-width: 328px;
-  }
-
-  .container {
-    gap: 16px;
   }
 }

--- a/src/pages/interview/QuestionPage/ui/QuestionPage.module.css
+++ b/src/pages/interview/QuestionPage/ui/QuestionPage.module.css
@@ -116,7 +116,7 @@
 .popover-additional {
   position: absolute;
   top: 16px;
-  right: 20px;
+  right: 16px;
   display: none;
   justify-content: center;
   align-items: center;
@@ -147,6 +147,13 @@
     gap: 20px;
     width: 360px;
     height: auto;
+  }
+}
+
+@media (width <= 767px) {
+  .popover-additional {
+    top: 20px;
+    right: 10px;
   }
 }
  

--- a/src/pages/interview/QuestionsPage/ui/QuestionsPage/QuestionsPage.module.css
+++ b/src/pages/interview/QuestionsPage/ui/QuestionsPage/QuestionsPage.module.css
@@ -11,7 +11,7 @@
 
 .filters-mobile {
   position: absolute;
-  top: 16px;
+  top: 24px;
   right: 20px;
   display: none;
   justify-content: center;
@@ -54,8 +54,16 @@
   }
 }
 
-@media (width < 480px) {
+@media (width <= 1023px) {
   .filters-mobile {
-    top: 10px;
+    top: 16px;
+    right: 16px;
+  }
+}
+
+@media (width <= 767px) {
+  .filters-mobile {
+    top: 20px;
+    right: 10px;
   }
 }

--- a/src/shared/ui/AdditionalStatInfoGauge/ui/AdditionalStatInfoGauge/AdditionalStatInfoGauge.module.css
+++ b/src/shared/ui/AdditionalStatInfoGauge/ui/AdditionalStatInfoGauge/AdditionalStatInfoGauge.module.css
@@ -1,8 +1,4 @@
-.wrapper {
-  padding-top: 12px;
-}
-
-@media (width < 728px) {
+@media (width <= 767px) {
   .wrapper {
     gap: 12px;
   }

--- a/src/shared/ui/Breadcrumbs/ui/Breadcrumbs.module.css
+++ b/src/shared/ui/Breadcrumbs/ui/Breadcrumbs.module.css
@@ -11,12 +11,16 @@
   gap: 8px;
 }
 
-@media (width <= 768px) {
+@media (width <= 767px) {
   .item:not(:nth-last-child(2)) {
     display: none;
   }
 
   .item:nth-last-child(2) .icon {
     transform: rotate(180deg);
+  }
+
+  .list {
+    margin-bottom: 20px;
   }
 }

--- a/src/shared/ui/Card/ui/Card.module.css
+++ b/src/shared/ui/Card/ui/Card.module.css
@@ -17,6 +17,7 @@
 
 .card-header-title-center {
   justify-content: center;
+  margin-bottom: 24px;
 }
 
 .content {
@@ -122,9 +123,12 @@
   } 
 }
 
-@media (width <= 768px) {   
+@media (width <= 767px) {   
   .card {
-    max-width: 100%; 
+    gap: 0; 
+    padding: 20px 10px;
+    max-width: 100%;
+    border-radius: 12px;
   }
 
   .header {
@@ -135,12 +139,13 @@
 
   .link {
     position: absolute;
-    right: 20px;
+    right: 10px;
     bottom: 20px;
+    padding-top: 20px;
   }
 
   .content {
-    margin-bottom: 36px;
+    margin-bottom: 44px;
   }
 }
 
@@ -157,6 +162,12 @@
 
   .content {
     margin-bottom: 40px;
+  }
+}
+
+@media (width <= 368px) {
+  .card-header {
+    text-align: center;
   }
 }
 

--- a/src/shared/ui/Card/ui/Card.tsx
+++ b/src/shared/ui/Card/ui/Card.tsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 
 import Arrow from '@/shared/assets/icons/arrowShortDown.svg';
 import { i18Namespace } from '@/shared/config/i18n';
-import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { Icon } from '@/shared/ui/Icon/ui/Icon';
 import { Text } from '@/shared/ui/Text';
 
@@ -90,8 +89,6 @@ export const Card = ({
 	const [contentHeight, setContentHeight] = useState(0);
 	const { t } = useTranslation(i18Namespace.translation);
 
-	const { isMobile } = useScreenSize();
-
 	useLayoutEffect(() => {
 		if (expandable) {
 			const changeContentHeight = () => {
@@ -142,7 +139,7 @@ export const Card = ({
 						[styles['card-header-title-center']]: isTitleCenter,
 					})}
 				>
-					{title && <Text variant={isMobile ? 'body4' : 'body5'}>{title}</Text>}
+					{title && <Text variant="body5-accent">{title}</Text>}
 					{actionRoute ? (
 						<Link
 							to={actionRoute}

--- a/src/shared/ui/ProgressBar/ui/ProgressBar.tsx
+++ b/src/shared/ui/ProgressBar/ui/ProgressBar.tsx
@@ -27,7 +27,7 @@ export const ProgressBar = ({
 				max={totalCount}
 			/>
 			{label && (
-				<Text variant="body1-accent" className={styles[`label-${variant}`]}>
+				<Text variant="body2-accent" color="black-500" className={styles[`label-${variant}`]}>
 					{label}
 				</Text>
 			)}

--- a/src/widgets/Header/ui/HeaderLayout/HeaderLayout.module.css
+++ b/src/widgets/Header/ui/HeaderLayout/HeaderLayout.module.css
@@ -32,10 +32,10 @@
   }
 }
 
-@media (width <= 768px) {
+@media (width <= 767px) {
   .header {
     justify-content: space-between;
-    padding: 15px 20px;
+    padding: 10px;
   }
 }
 

--- a/src/widgets/interview/CategoryProgressList/ui/CategoryProgressList/CategoryProgressList.tsx
+++ b/src/widgets/interview/CategoryProgressList/ui/CategoryProgressList/CategoryProgressList.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 
 import { i18Namespace } from '@/shared/config/i18n';
 import { InterviewStatistics } from '@/shared/config/i18n/i18nTranslations';
+import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { Card } from '@/shared/ui/Card';
 import { Flex } from '@/shared/ui/Flex';
 
@@ -19,11 +20,16 @@ export interface CategoryProgressListProps {
 
 export const CategoryProgressList = ({ className, skillsStat }: CategoryProgressListProps) => {
 	const { t } = useTranslation(i18Namespace.interviewStatistics);
+	const { isMobile } = useScreenSize();
 
 	const transformSkillsStat = skillsStat ? transformSkillsArray(skillsStat) : [];
 
 	return (
-		<Card className={className} title={t(InterviewStatistics.PROGRESS_TITLE)}>
+		<Card
+			className={className}
+			title={t(InterviewStatistics.PROGRESS_TITLE)}
+			isTitleCenter={isMobile}
+		>
 			<Flex direction="column" gap="12" className={styles.list}>
 				{transformSkillsStat.map((skillStat) => (
 					<CategoryProgressItem key={skillStat.category} progressData={skillStat} />

--- a/src/widgets/interview/InterviewPreparation/ui/InterviewPreparation/InterviewPreparation.skeleton.tsx
+++ b/src/widgets/interview/InterviewPreparation/ui/InterviewPreparation/InterviewPreparation.skeleton.tsx
@@ -15,6 +15,7 @@ export const InterviewPreparationSkeleton = ({ className }: InterviewPreparation
 			actionTitle="actionTitle"
 			actionRoute="actionRoute"
 			withShadow={!isMobile}
+			isTitleCenter={isMobile}
 		>
 			<PreviewActiveQuizSkeleton />
 		</CardSkeleton>

--- a/src/widgets/interview/InterviewPreparation/ui/InterviewPreparation/InterviewPreparation.tsx
+++ b/src/widgets/interview/InterviewPreparation/ui/InterviewPreparation/InterviewPreparation.tsx
@@ -51,6 +51,7 @@ export const InterviewPreparation = ({ className }: InterviewPreparationProps) =
 			actionTitle={interviewPreparationActionTitle}
 			actionRoute={interviewPreparationActionRoute}
 			withShadow={!isMobile}
+			isTitleCenter={isMobile}
 		>
 			{isSpecializationEmpty && <SpecializationEmptyStub />}
 			{lastActiveQuizInfo && !isSpecializationEmpty && <PreviewActiveQuiz />}

--- a/src/widgets/interview/InterviewPreparation/ui/PreviewActiveQuiz/PreviewActiveQuiz.module.css
+++ b/src/widgets/interview/InterviewPreparation/ui/PreviewActiveQuiz/PreviewActiveQuiz.module.css
@@ -15,11 +15,13 @@
   }
 }
 
-@media (width <= 480px) {
+@media (width <= 767px) {
   .preparation {
     padding: 0;
   }
-	
+}
+
+@media (width <= 480px) {	
   .image-wrapper {
     height: 170px;
     border-radius: 16px;

--- a/src/widgets/interview/PassedQuizzesList/ui/PreviewPassedQuizzesItem/PreviewPassedQuizzesItem.tsx
+++ b/src/widgets/interview/PassedQuizzesList/ui/PreviewPassedQuizzesItem/PreviewPassedQuizzesItem.tsx
@@ -7,6 +7,7 @@ import { InterviewHistory } from '@/shared/config/i18n/i18nTranslations';
 import { ROUTES } from '@/shared/config/router/routes';
 import { formatDate } from '@/shared/helpers/formatDate';
 import { route } from '@/shared/helpers/route';
+import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { Flex } from '@/shared/ui/Flex';
 import { Text } from '@/shared/ui/Text';
 
@@ -24,6 +25,7 @@ export const PreviewPassedQuizzesItem = ({ interview }: InterviewHistoryItemProp
 	const { id, successCount, fullCount } = interview;
 	const incorrectAnswersCount = fullCount - successCount;
 	const { t } = useTranslation(i18Namespace.interviewHistory);
+	const { isMobile } = useScreenSize();
 	const formattedDate = formatDate(parseISO(interview.endDate));
 
 	return (
@@ -33,7 +35,7 @@ export const PreviewPassedQuizzesItem = ({ interview }: InterviewHistoryItemProp
 					{formattedDate}
 				</Text>
 				<Flex wrap="wrap" justify="between" gap="14" className={styles.info}>
-					<Text variant="body4">
+					<Text variant={isMobile ? 'body3-accent' : 'body4'}>
 						{t(InterviewHistory.QUIZ_TITLE, { number: interview.quizNumber })}
 					</Text>
 					<Flex componentType="ul" gap="24">

--- a/src/widgets/interview/PassedQuizzesList/ui/PreviewPassedQuizzesList/PreviewPassedQuizzesList.skeleton.tsx
+++ b/src/widgets/interview/PassedQuizzesList/ui/PreviewPassedQuizzesList/PreviewPassedQuizzesList.skeleton.tsx
@@ -1,3 +1,4 @@
+import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { CardSkeleton } from '@/shared/ui/Card';
 import { Flex } from '@/shared/ui/Flex';
 
@@ -7,6 +8,8 @@ import { InterviewHistoryListProps } from './PreviewPassedQuizzesList';
 import styles from './PreviewPassedQuizzesList.module.css';
 
 export const PreviewPassedQuizzesListSkeleton = ({ className }: InterviewHistoryListProps) => {
+	const { isMobile } = useScreenSize();
+
 	return (
 		<CardSkeleton
 			className={className}
@@ -14,6 +17,7 @@ export const PreviewPassedQuizzesListSkeleton = ({ className }: InterviewHistory
 			actionTitle="actionTitle"
 			title="title"
 			withShadow
+			isTitleCenter={isMobile}
 		>
 			<Flex componentType="ul" direction="column" gap="8" className={styles.list}>
 				{[...Array(3)].map((_, index) => (

--- a/src/widgets/interview/PassedQuizzesList/ui/PreviewPassedQuizzesList/PreviewPassedQuizzesList.tsx
+++ b/src/widgets/interview/PassedQuizzesList/ui/PreviewPassedQuizzesList/PreviewPassedQuizzesList.tsx
@@ -5,6 +5,7 @@ import { InterviewHistory, Profile } from '@/shared/config/i18n/i18nTranslations
 import { ROUTES } from '@/shared/config/router/routes';
 import { EMAIL_VERIFY_SETTINGS_TAB } from '@/shared/constants/customRoutes';
 import { useAppSelector } from '@/shared/hooks/useAppSelector';
+import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { Card } from '@/shared/ui/Card';
 import { Flex } from '@/shared/ui/Flex';
 import { Text } from '@/shared/ui/Text';
@@ -31,6 +32,8 @@ export const PreviewPassedQuizzesList = ({ className }: InterviewHistoryListProp
 		uniqueKey: 'interviewPreviewHistory',
 	});
 
+	const { isMobile } = useScreenSize();
+
 	const isEmptyData = isSuccess && data.data.length === 0;
 
 	const actionRoute = isVerified ? ROUTES.interview.history.page : EMAIL_VERIFY_SETTINGS_TAB;
@@ -46,6 +49,7 @@ export const PreviewPassedQuizzesList = ({ className }: InterviewHistoryListProp
 			title={t(InterviewHistory.TITLE)}
 			withShadow
 			actionDisabled={isEmptyData}
+			isTitleCenter={isMobile}
 		>
 			{!isVerified && (
 				<Text variant="body4" color="black-700" className={styles['no-history']}>

--- a/src/widgets/question/QuestionHeader/QuestionHeader.tsx
+++ b/src/widgets/question/QuestionHeader/QuestionHeader.tsx
@@ -41,13 +41,15 @@ export const QuestionHeader = ({ title, description, status, isPublic }: Questio
 			{isMobile ? (
 				<div className={styles['question-header-wrapper']}>
 					<div className={styles['title-wrapper']}>
-						<Text className={styles.title} variant="body5">
+						<Text className={styles.title} variant="body6">
 							{title}
 						</Text>
 						{isPublic && <StatusLabel />}
 					</div>
 					<div className={styles['description-wrapper']}>
-						<Text variant="body3">{description}</Text>
+						<Text variant="body3-accent" color="black-700">
+							{description}
+						</Text>
 					</div>
 				</div>
 			) : (

--- a/src/widgets/question/QuestionsList/ui/PreviewQuestionsList/PreviewQuestionsList.skeleton.tsx
+++ b/src/widgets/question/QuestionsList/ui/PreviewQuestionsList/PreviewQuestionsList.skeleton.tsx
@@ -1,3 +1,4 @@
+import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { CardSkeleton } from '@/shared/ui/Card';
 import { Flex } from '@/shared/ui/Flex';
 
@@ -7,6 +8,7 @@ import { PreviewQuestionsListProps } from './PreviewQuestionsList';
 import styles from './PreviewQuestionsList.module.css';
 
 export const PreviewQuestionsListSkeleton = ({ className }: PreviewQuestionsListProps) => {
+	const { isMobile } = useScreenSize();
 	return (
 		<CardSkeleton
 			className={className}
@@ -14,6 +16,7 @@ export const PreviewQuestionsListSkeleton = ({ className }: PreviewQuestionsList
 			actionTitle="actionTitle"
 			actionRoute="actionRoute"
 			withShadow
+			isTitleCenter={isMobile}
 		>
 			<Flex componentType="ul" direction="column" gap="12" className={styles.list}>
 				{[...Array(3)].map((_, index) => (

--- a/src/widgets/question/QuestionsList/ui/PreviewQuestionsList/PreviewQuestionsList.tsx
+++ b/src/widgets/question/QuestionsList/ui/PreviewQuestionsList/PreviewQuestionsList.tsx
@@ -4,6 +4,7 @@ import { i18Namespace } from '@/shared/config/i18n';
 import { Questions } from '@/shared/config/i18n/i18nTranslations';
 import { ROUTES } from '@/shared/config/router/routes';
 import { useAppSelector } from '@/shared/hooks/useAppSelector';
+import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { Card } from '@/shared/ui/Card';
 import { Flex } from '@/shared/ui/Flex';
 import { Text } from '@/shared/ui/Text';
@@ -30,6 +31,8 @@ export const PreviewQuestionsList = ({ className }: PreviewQuestionsListProps) =
 		specialization: specializationId,
 	});
 
+	const { isMobile } = useScreenSize();
+
 	const questions = response?.data ?? [];
 
 	const isEmptyData = isSuccess && questions.length === 0;
@@ -49,6 +52,7 @@ export const PreviewQuestionsList = ({ className }: PreviewQuestionsListProps) =
 			actionTitle={t(Questions.PREVIEW_LINK)}
 			actionRoute={ROUTES.interview.questions.page}
 			withShadow
+			isTitleCenter={isMobile}
 		>
 			<Flex componentType="ul" direction="column" gap="12" className={styles.list}>
 				{questions.map((question) => (


### PR DESCRIPTION
Основные правки:
- Заголовки на мобильной версии выровнены по центру
- Размер текста заголовков приведен в соответствие дизайну
- Отступы внутри блоков 16px => padding: 20px 10px
- Отступ от контента до ссылки - 20рх
- MainLayout <= 767px padding: 16px => padding: 20px 10px
- Отступ от заголовка - 24px
- Убраны лишние падинги, марджины, гэпы в разных частях кода
- Контрольная точка <728 изменена на <=767. В нескольких местах также поправлены другие КТ.
- Скелетоны поправлены в части центровки заголовков по центру
- HeaderLayout <= 767 padding: 15px 20px => padding: 10px