### PR TITLE
YH-901: fixed question title style & footer LogoText

### DIFF
--- a/src/shared/ui/AppLogo/AppLogo.tsx
+++ b/src/shared/ui/AppLogo/AppLogo.tsx
@@ -43,9 +43,13 @@ export const AppLogo = ({
 					alt="Тренажер собеседований и вопросы собеседований в IT"
 				/>
 			)}
-			{!isOpen && (
+			{(!isOpen || navigationFooter) && (
 				<LogoText
-					className={classNames(styles['logo-text'], styles['logo-text-header'], styles[fill])}
+					className={classNames(
+						styles['logo-text'],
+						{ [styles['logo-text-header']]: !navigationFooter },
+						styles[fill],
+					)}
 				/>
 			)}
 		</NavLink>

--- a/src/widgets/interview/PassedQuestionsList/ui/PassedQuestionsItem/PassedQuestionsItem.tsx
+++ b/src/widgets/interview/PassedQuestionsList/ui/PassedQuestionsItem/PassedQuestionsItem.tsx
@@ -7,6 +7,7 @@ import { InterviewQuiz } from '@/shared/config/i18n/i18nTranslations';
 import { ROUTES } from '@/shared/config/router/routes';
 import { route } from '@/shared/helpers/route';
 import { useCurrentProject } from '@/shared/hooks/useCurrentProject';
+import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { Flex } from '@/shared/ui/Flex';
 import { Icon, IconName } from '@/shared/ui/Icon';
 import { ImageWithWrapper } from '@/shared/ui/ImageWithWrapper';
@@ -28,6 +29,7 @@ interface QuestionAnswerItem {
 export const PassedQuestionsItem = ({ question }: PassedQuestionsItemProps) => {
 	const { t } = useTranslation(i18Namespace.interviewQuiz);
 	const project = useCurrentProject();
+	const { isMobile } = useScreenSize();
 
 	const { imageSrc, answer, questionTitle, questionId } = question;
 
@@ -52,7 +54,7 @@ export const PassedQuestionsItem = ({ question }: PassedQuestionsItemProps) => {
 			<li className={styles.item}>
 				<ImageWithWrapper src={imageSrc} className={styles.img} />
 				<Flex direction="column" gap="8" maxWidth>
-					<Text variant="body4" maxRows={2} color="black-800">
+					<Text variant={isMobile ? 'body3-accent' : 'body4'} maxRows={2} color="black-800">
 						{questionTitle}
 					</Text>
 					<Chip


### PR DESCRIPTION
1. Исправлен заголовок вопроса в списке вопросов на странице результатов публичного квиза (согласно макета)
2. Исправлено отображение текста логотипа в футере на мобильном экране. Ранее не отображалось.