### PR TITLE
YH-905: fixed bug with empty array into LS when create new quiz

### DIFF
--- a/src/entities/quiz/api/quizApi.ts
+++ b/src/entities/quiz/api/quizApi.ts
@@ -4,7 +4,7 @@ import i18n from '@/shared/config/i18n/i18n';
 import { Translation } from '@/shared/config/i18n/i18nTranslations';
 import { ROUTES } from '@/shared/config/router/routes';
 import { ExtraArgument } from '@/shared/config/store/types';
-import { getJSONFromLS, setToLS } from '@/shared/helpers/manageLocalStorage';
+import { setToLS } from '@/shared/helpers/manageLocalStorage';
 import { route } from '@/shared/helpers/route';
 import { Response } from '@/shared/types/types';
 import { toast } from '@/shared/ui/Toast';
@@ -14,6 +14,7 @@ import {
 	LS_ACTIVE_QUIZ_KEY,
 	quizApiUrls,
 } from '../model/constants/quizConstants';
+import { getValidActiveQuizFromLS } from '../model/helpers/getValidActiveQuizFromLS';
 import { clearActiveQuizState, setActiveQuizQuestions } from '../model/slices/activeQuizSlice';
 import {
 	CreateNewQuizParamsRequest,
@@ -28,6 +29,7 @@ import {
 	GetQuizHistoryParamsRequest,
 	GetQuizHistoryResponse,
 	interruptQuizRequest,
+	Answers,
 } from '../model/types/quiz';
 import { getActiveQuizQuestions } from '../utils/getActiveQuizQuestions';
 
@@ -68,8 +70,8 @@ const quizApi = baseApi.injectEndpoints({
 			providesTags: [ApiTags.NEW_QUIZ],
 			async onQueryStarted(_, { queryFulfilled, extra, dispatch }) {
 				try {
-					const { data: questions } = await queryFulfilled;
-					questions && setToLS(LS_ACTIVE_MOCK_QUIZ_KEY, questions);
+					const { data: mockQuizResponse } = await queryFulfilled;
+					mockQuizResponse && setToLS(LS_ACTIVE_MOCK_QUIZ_KEY, mockQuizResponse);
 					const typedExtra = extra as ExtraArgument;
 					toast.success(i18n.t(Translation.TOAST_INTERVIEW_NEW_QUIZ_SUCCESS));
 					typedExtra.navigate(ROUTES.quiz.new.page);
@@ -89,11 +91,27 @@ const quizApi = baseApi.injectEndpoints({
 			async onQueryStarted(_, { dispatch, queryFulfilled }) {
 				try {
 					const result = await queryFulfilled;
-					const localActiveQuiz = getJSONFromLS(LS_ACTIVE_QUIZ_KEY);
+					const activeQuizQuestionsFromLS = getValidActiveQuizFromLS(LS_ACTIVE_QUIZ_KEY);
 
-					dispatch(
-						setActiveQuizQuestions(localActiveQuiz ?? getActiveQuizQuestions(result.data?.data[0])),
-					);
+					if (activeQuizQuestionsFromLS) {
+						dispatch(
+							setActiveQuizQuestions({
+								questions: activeQuizQuestionsFromLS,
+								shouldSaveToLS: false,
+							}),
+						);
+					} else {
+						const parsedQuestions: Answers[] = getActiveQuizQuestions(result.data?.data[0]).map(
+							(question) => ({
+								questionId: question.questionId,
+								questionTitle: question.questionTitle,
+								answer: question.answer,
+								shortAnswer: question.shortAnswer ?? '',
+								imageSrc: question.imageSrc ?? undefined,
+							}),
+						);
+						dispatch(setActiveQuizQuestions({ questions: parsedQuestions }));
+					}
 				} catch (error) {
 					// eslint-disable-next-line no-console
 					console.error(error);
@@ -164,14 +182,13 @@ const quizApi = baseApi.injectEndpoints({
 			async onQueryStarted({ data }, { queryFulfilled, extra, dispatch }) {
 				try {
 					await queryFulfilled;
+					dispatch(clearActiveQuizState());
 					await dispatch(
 						quizApi.endpoints.getActiveQuiz.initiate(
 							{ profileId: data.profileId, page: 1, limit: 1 },
 							{ forceRefetch: true },
 						),
 					).unwrap();
-					dispatch(clearActiveQuizState());
-
 					const typedExtra = extra as ExtraArgument;
 					toast.success(i18n.t(Translation.TOAST_INTERVIEW_FINISH_SUCCESS));
 					typedExtra.navigate(route(ROUTES.interview.quiz.page));

--- a/src/entities/quiz/hooks/useSlideSwitcher.ts
+++ b/src/entities/quiz/hooks/useSlideSwitcher.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { matchPath, useLocation } from 'react-router-dom';
 
 // eslint-disable-next-line
 import { useAppDispatch } from '@/shared/hooks';
@@ -7,15 +8,20 @@ import { changeQuestionAnswer } from '../model/slices/activeQuizSlice';
 import { Answers, QuizQuestionAnswerType } from '../model/types/quiz';
 
 export const useSlideSwitcher = (questions: Answers[]) => {
-	const dispatch = useAppDispatch();
 	const [currentQuestion, setCurrentQuestion] = useState(0);
-	const currentCount = questions.filter((question) => Boolean(question.answer)).length;
+
+	const dispatch = useAppDispatch();
+	const location = useLocation();
+
+	const answeredCount = questions.filter((question) => question.answer !== undefined).length;
+	const isAuthRoute = !!matchPath('/dashboard/interview/new', location.pathname);
 
 	const changeAnswer = (answer: QuizQuestionAnswerType) => {
 		dispatch(
 			changeQuestionAnswer({
 				questionId: questions[currentQuestion].questionId,
 				answer,
+				shouldSaveToLS: isAuthRoute,
 			}),
 		);
 	};
@@ -32,7 +38,7 @@ export const useSlideSwitcher = (questions: Answers[]) => {
 		...questions[currentQuestion],
 		totalCount: questions.length,
 		activeQuestion: currentQuestion + 1,
-		currentCount,
+		answeredCount,
 		changeAnswer,
 		goToNextSlide,
 		goToPrevSlide,

--- a/src/entities/quiz/model/helpers/getValidActiveQuizFromLS.ts
+++ b/src/entities/quiz/model/helpers/getValidActiveQuizFromLS.ts
@@ -1,0 +1,9 @@
+import { getJSONFromLS } from '@/shared/helpers/manageLocalStorage';
+
+import { Answers } from '@/entities/quiz';
+
+export const getValidActiveQuizFromLS = (key: string): Answers[] | null => {
+	const activeQuizFromLS = getJSONFromLS(key);
+
+	return Array.isArray(activeQuizFromLS) && activeQuizFromLS.length > 0 ? activeQuizFromLS : null;
+};

--- a/src/entities/quiz/model/helpers/updateQuestionAnswer.ts
+++ b/src/entities/quiz/model/helpers/updateQuestionAnswer.ts
@@ -1,0 +1,10 @@
+import { Answers, ChangeQuestionAnswerParams } from '../types/quiz';
+
+export const updateQuestionAnswer = (
+	questions: Answers[],
+	params: ChangeQuestionAnswerParams,
+): Answers[] => {
+	return questions.map((question) =>
+		question.questionId === params.questionId ? { ...question, answer: params.answer } : question,
+	);
+};

--- a/src/entities/quiz/model/types/quiz.ts
+++ b/src/entities/quiz/model/types/quiz.ts
@@ -40,6 +40,7 @@ export interface ActiveQuizState {
 export interface ChangeQuestionAnswerParams {
 	questionId: number;
 	answer: QuizQuestionAnswerType;
+	shouldSaveToLS?: boolean;
 }
 
 export interface ProgressByCategoriesData {

--- a/src/pages/interview/InterviewQuizPage/ui/InterviewQuizPage.tsx
+++ b/src/pages/interview/InterviewQuizPage/ui/InterviewQuizPage.tsx
@@ -48,7 +48,7 @@ const InterviewQuizPage = () => {
 		questionTitle,
 		imageSrc,
 		shortAnswer,
-		currentCount,
+		answeredCount,
 		activeQuestion,
 		totalCount,
 		answer,
@@ -120,7 +120,7 @@ const InterviewQuizPage = () => {
 						</span>
 						<ProgressBar
 							className={styles['progress-component']}
-							currentCount={currentCount}
+							currentCount={answeredCount}
 							totalCount={totalCount}
 						/>
 					</div>

--- a/src/pages/landing/PublicQuizPage/ui/PublicQuizPage.tsx
+++ b/src/pages/landing/PublicQuizPage/ui/PublicQuizPage.tsx
@@ -56,7 +56,7 @@ const PublicQuizPage = () => {
 		questionTitle,
 		imageSrc,
 		shortAnswer,
-		currentCount,
+		answeredCount,
 		activeQuestion,
 		totalCount,
 		answer,
@@ -118,7 +118,7 @@ const PublicQuizPage = () => {
 					</span>
 					<ProgressBar
 						className={styles['progress-component']}
-						currentCount={currentCount}
+						currentCount={answeredCount}
 						totalCount={totalCount}
 					/>
 				</div>


### PR DESCRIPTION
Баг: при создании квиза под авторизованным юзером, квиз создавался без заголовка вопросов, счетчик вопросов был некорректным, невозможно было ни завершить такой "битый" квиз, ни пройти.
Происходило это только в том случае, если предварительно пройти публичный квиз. При этом публичный квиз отрабатывал корректно на всех этапах.

Проблема была в том, что оба квиза используют один слайс. 
Внутри слайса, в редьюсерах, не было никакой проверки данных перед созданием ключа  **activeQuiz** в ЛС. 
При этом запись ключа  **activeQuiz** в ЛС производилась без условия, без разделения на основной квиз, или публичный.
Более того, создание ключа **activeQuiz** в ЛС происходило не на шаге создания квиза, а на шаге ответа на вопрос - ЗНАЮ, или НЕ ЗНАЮ, что тоже ошибочно.
```
changeQuestionAnswer: (state, action: PayloadAction<ChangeQuestionAnswerParams>) => {
    state.questions = state.questions.map((question) => {
        if (question.questionId === action.payload.questionId) {
	    return { ...question, answer: action.payload.answer };
	}
	return question;
    });
    setToLS(LS_ACTIVE_QUIZ_KEY, state.questions);
},
```

В **quizApi.ts** данные диспатчились напрямую, с минимальной проверкой и без подготовки:
```
async onQueryStarted(_, { dispatch, queryFulfilled }) {
    try {
	const result = await queryFulfilled;
	const localActiveQuiz = getJSONFromLS(LS_ACTIVE_QUIZ_KEY);
	dispatch(
	    setActiveQuizQuestions(localActiveQuiz ?? getActiveQuizQuestions(result.data?.data[0])),
        );
```

**Что сделано в данном PR:**
    - в редьюсер **setActiveQuizQuestions** в **activeQuizSlice** добавлена опциональная логика сохранения в LS:
        - в payload теперь можно передать флаг **shouldSaveToLS**. По умолчанию он true, но при явной передаче false — 
        данные сохраняются только в Redux, без записи в LS.
    - вынесена логика изменения ответа на вопрос в отдельную утилиту **updateQuestionAnswer**
    - редьюсер **changeQuestionAnswer** в **activeQuizSlice** теперь использует эту утилиту
    - проверяется наличие вопросов перед записью в **Local Storage**
    - добавлен флаг **shouldSaveToLS** перед записью в Local Storage для управления данными (авторизованные и 
    неавторизованные пользователи)


**Обновление API-слоя (quizApi.ts)**
Добавлена проверка состояния в **LocalStorage**:
    - добавлена проверка на наличие валидных данных в LocalStorage через новую утилиту **getValidActiveQuizFromLS**
    - если в **LocalStorage** под ключом **activeQuiz** есть валидные данные (**getValidActiveQuizFromLS**) — они 
    используются в приоритете
    - эти данные подгружаются в Redux без повторного сохранения (**shouldSaveToLS: false)**, что предотвращает 
    ненужную перезапись состояния
    - если в LS нет валидных данных, происходит парсинг данных из ответа API (**result.data?.data[0]**) с помощью 
    **getActiveQuizQuestions**. Каждое поле вопроса нормализуется. Далее результат диспатчится в Redux через 
    **setActiveQuizQuestions**, с сохранением в LS по умолчанию (**так как shouldSaveToLS не указан, сохраняется true**).
    
**Изменения в хуке useSlideSwitcher**
    - внутри функции **changeAnswer** теперь учитывается текущий маршрут. Добавлена проверка **isAuthRoute** на 
    основе **useLocation** и **matchPath**. В зависимости от маршрута (авторизованный / публичный) передаётся 
    флаг **shouldSaveToLS**:
`    shouldSaveToLS: isAuthRoute
`
Это обеспечивает дифференцированное поведение сохранения ответов: в LocalStorage сохраняются только ответы авторизованного пользователя.
 