### PR TITLE
YH-906: fix resets the question filter

### DIFF
--- a/src/shared/hooks/useQueryFilter.ts
+++ b/src/shared/hooks/useQueryFilter.ts
@@ -1,11 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import {
-	DEFAULT_PAGE,
-	DEFAULT_SPECIALIZATION_NUMBER,
-	DEFAULT_STATUS,
-} from '../constants/queryConstants';
+import { DEFAULT_SPECIALIZATION_NUMBER } from '../constants/queryConstants';
 
 type QuestionFilterStatus = 'all' | 'learned' | 'not-learned';
 
@@ -97,21 +93,9 @@ export const useQueryFilter = () => {
 			const curFilter = newFilters[key as keyof FilterFromUser];
 
 			if (curFilter !== undefined && curFilter !== null) {
-				if (key === 'page' && Number(newFilters.page) === Number(params.get('page'))) {
-					params.set(key, DEFAULT_PAGE);
-					return;
-				}
-
-				if (key === 'status' && newFilters.status === params.get('status')) {
-					params.set(key, DEFAULT_STATUS);
-					return;
-				}
-
 				if (key === 'tariff') {
 					params.set('isFree', curFilter.toString());
 					return;
-				} else {
-					params.set(key, curFilter.toString());
 				}
 
 				if (Array.isArray(curFilter)) {


### PR DESCRIPTION
Исправил сбрасывание фильтра на странице вопросов.
При выборе статуса "Изучено" происходила фильтрация вопросов, но при переходе на вторую страницу (в пагинации) фильтр сбрасывался на значение "Все".

Ошибка заключалась скорее всего в useQueryFilter, из-за которого фильтр status сбрасывался на 'all' при смене страницы. Удалил некорректные проверки в updateQueryParams, которые принудительно устанавливали DEFAULT_STATUS при совпадении текущего значения. Теперь status сохраняется при пагинации.