### PR TITLE
YH-972: Fix missing validation messages in specialization form

### DIFF
--- a/src/features/specialization/createSpecialization/model/lib/validation/specializationCreateSchema.ts
+++ b/src/features/specialization/createSpecialization/model/lib/validation/specializationCreateSchema.ts
@@ -1,11 +1,14 @@
 import * as yup from 'yup';
 
+import i18n from '@/shared/config/i18n/i18n';
+import { Translation } from '@/shared/config/i18n/i18nTranslations';
+
 import { CreateSpecializationFormValues } from '../../types/specializationCreateTypes';
 
 export const specializationCreateSchema: yup.ObjectSchema<CreateSpecializationFormValues> = yup
 	.object()
 	.shape({
-		title: yup.string().required(),
-		description: yup.string().required(),
+		title: yup.string().required(i18n.t(Translation.VALIDATION_REQUIRED)),
+		description: yup.string().required(i18n.t(Translation.VALIDATION_REQUIRED)),
 		imageSrc: yup.string(),
 	});

--- a/src/features/specialization/editSpecialization/model/lib/validation/specializationEditSchema.ts
+++ b/src/features/specialization/editSpecialization/model/lib/validation/specializationEditSchema.ts
@@ -1,13 +1,16 @@
 import * as yup from 'yup';
 
+import i18n from '@/shared/config/i18n/i18n';
+import { Translation } from '@/shared/config/i18n/i18nTranslations';
+
 import { EditSpecializationFormValues } from '../../types/specializationEditPageTypes';
 
 export const specializationEditSchema: yup.ObjectSchema<EditSpecializationFormValues> = yup
 	.object()
 	.shape({
 		id: yup.number().required(),
-		title: yup.string().required(),
-		description: yup.string().required(),
+		title: yup.string().required(i18n.t(Translation.VALIDATION_REQUIRED)),
+		description: yup.string().required(i18n.t(Translation.VALIDATION_REQUIRED)),
 		imageSrc: yup.string().nullable(),
 		createdAt: yup.string().required(),
 		updatedAt: yup.string().required(),


### PR DESCRIPTION
Добавлены русские переводы для сообщений валидации в форме создания и редактирования специализации. Ошибки теперь отображаются на русском языке.