### PR TITLE
YH-980: Add tooltips to sidebar items for admin users

### DIFF
--- a/src/app/layouts/MainLayout/ui/MainLayout.tsx
+++ b/src/app/layouts/MainLayout/ui/MainLayout.tsx
@@ -57,7 +57,6 @@ export const MainLayout = ({ sidebarItems, onlyAdmin }: MainLayoutProps) => {
 					<div className={styles.sidebar}>
 						<Sidebar
 							menuItems={filteredMenuItems}
-							isAdmin={onlyAdmin}
 							onOpenSidebarDrawer={onToggleOpenSidebarDrawer}
 							isOpenSidebarDrawer={isOpenSidebarDrawer}
 							setIsOpenSidebarDrawer={setIsOpenSidebarDrawer}

--- a/src/app/layouts/MainLayout/ui/MainLayout.tsx
+++ b/src/app/layouts/MainLayout/ui/MainLayout.tsx
@@ -57,6 +57,7 @@ export const MainLayout = ({ sidebarItems, onlyAdmin }: MainLayoutProps) => {
 					<div className={styles.sidebar}>
 						<Sidebar
 							menuItems={filteredMenuItems}
+							isAdmin={onlyAdmin}
 							onOpenSidebarDrawer={onToggleOpenSidebarDrawer}
 							isOpenSidebarDrawer={isOpenSidebarDrawer}
 							setIsOpenSidebarDrawer={setIsOpenSidebarDrawer}

--- a/src/widgets/Sidebar/ui/Sidebar/Sidebar.tsx
+++ b/src/widgets/Sidebar/ui/Sidebar/Sidebar.tsx
@@ -27,8 +27,6 @@ interface SidebarProps {
 	/**
 	 * Is a mobile option
 	 */
-	isAdmin?: boolean;
-
 	isMobileSidebar?: boolean;
 
 	onOpenSidebarDrawer?: () => void;
@@ -45,7 +43,6 @@ interface SidebarProps {
 
 export const Sidebar = ({
 	menuItems,
-	isAdmin = false,
 	isMobileSidebar = false,
 	onOpenSidebarDrawer,
 	isOpenSidebarDrawer,
@@ -55,7 +52,7 @@ export const Sidebar = ({
 	const { t } = useTranslation(i18Namespace.translation);
 	const [isOpenNavSidebar, setIsOpenNavSidebar] = useState<boolean>(false);
 	const [logout] = useLazyLogoutQuery();
-	const isShowTooltip = isAdmin && isOpenNavSidebar && isLargeScreen;
+	const isShowTooltip = isOpenNavSidebar && isLargeScreen;
 
 	useEffect(() => {
 		if (!isMobileSidebar) {

--- a/src/widgets/Sidebar/ui/Sidebar/Sidebar.tsx
+++ b/src/widgets/Sidebar/ui/Sidebar/Sidebar.tsx
@@ -27,6 +27,8 @@ interface SidebarProps {
 	/**
 	 * Is a mobile option
 	 */
+	isAdmin?: boolean;
+
 	isMobileSidebar?: boolean;
 
 	onOpenSidebarDrawer?: () => void;
@@ -43,15 +45,17 @@ interface SidebarProps {
 
 export const Sidebar = ({
 	menuItems,
+	isAdmin = false,
 	isMobileSidebar = false,
 	onOpenSidebarDrawer,
 	isOpenSidebarDrawer,
 	setIsOpenSidebarDrawer,
 }: SidebarProps) => {
-	const { isMobile, isTablet, isLaptop, isDesktop } = useScreenSize();
+	const { isMobile, isTablet, isLaptop, isDesktop, isLargeScreen } = useScreenSize();
 	const { t } = useTranslation(i18Namespace.translation);
 	const [isOpenNavSidebar, setIsOpenNavSidebar] = useState<boolean>(false);
 	const [logout] = useLazyLogoutQuery();
+	const isShowTooltip = isAdmin && isOpenNavSidebar && isLargeScreen;
 
 	useEffect(() => {
 		if (!isMobileSidebar) {
@@ -102,7 +106,11 @@ export const Sidebar = ({
 					</button>
 				</div>
 				<div className={styles.menu}>
-					<SidebarMenuList fullWidth={isOpenNavSidebar} menuItems={menuItems} />
+					<SidebarMenuList
+						fullWidth={isOpenNavSidebar}
+						menuItems={menuItems}
+						isShowTooltip={isShowTooltip}
+					/>
 				</div>
 				<Flex direction="column" gap="8" className={styles['bottom-actions']}>
 					<Button

--- a/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarCategoryMenuItem.tsx
+++ b/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarCategoryMenuItem.tsx
@@ -5,6 +5,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 
 import ArrowIcon from '@/shared/assets/icons/arrowShortDown.svg';
 import { i18Namespace } from '@/shared/config/i18n';
+import { Tooltip } from '@/shared/ui/Tooltip';
 import { isPathMatch } from '@/shared/utils/isPathMatch';
 
 import { CategoryMenuItem } from '../../model/types/sidebar';
@@ -14,9 +15,14 @@ import styles from './SidebarMenuItem.module.css';
 interface SidebarMenuCategoryItemProps {
 	menuItem: CategoryMenuItem;
 	fullWidth: boolean;
+	isShowTooltip?: boolean;
 }
 
-const SidebarCategoryMenuItem = ({ menuItem, fullWidth }: SidebarMenuCategoryItemProps) => {
+const SidebarCategoryMenuItem = ({
+	menuItem,
+	fullWidth,
+	isShowTooltip,
+}: SidebarMenuCategoryItemProps) => {
 	const location = useLocation();
 
 	const [expanded, setExpanded] = useState(location.pathname.includes(menuItem.elements[0].route));
@@ -36,34 +42,53 @@ const SidebarCategoryMenuItem = ({ menuItem, fullWidth }: SidebarMenuCategoryIte
 				[styles.fullwidth]: fullWidth,
 			})}
 		>
-			<button className={styles.container} onClick={handleExpand}>
-				<div className={styles.wrap}>
-					<ImageComponent className={styles.icon} />
-					<span className={classNames(styles.title)}>{t(menuItem.title)}</span>
-				</div>
-				<div className={styles.side}>
-					{!fullWidth && <ArrowIcon className={styles['category-expand-icon']} />}
-					{menuItem.notifications && (
-						<div className={styles.notifications}>{menuItem.notifications}</div>
-					)}
-				</div>
-			</button>
+			<Tooltip
+				title={t(menuItem.title)}
+				placement="right"
+				color="violet"
+				tooltipDelay={{ open: 0, close: 50 }}
+				shouldShowTooltip={isShowTooltip}
+			>
+				<button className={styles.container} onClick={handleExpand}>
+					<div className={styles.wrap}>
+						<ImageComponent className={styles.icon} />
+						<span className={classNames(styles.title)}>{t(menuItem.title)}</span>
+					</div>
+					<div className={styles.side}>
+						{!fullWidth && <ArrowIcon className={styles['category-expand-icon']} />}
+						{menuItem.notifications && (
+							<div className={styles.notifications}>{menuItem.notifications}</div>
+						)}
+					</div>
+				</button>
+			</Tooltip>
 			<div className={styles.items}>
 				{menuItem.elements.map((item, index) => {
 					const ImageComponent = item.icon;
 					const isActiveItem = isPathMatch(item.route, location.pathname);
 					return (
-						<NavLink
+						<Tooltip
 							key={index}
-							to={item.route}
-							end
-							className={classNames(styles.item, styles.nested, { [styles.active]: isActiveItem })}
+							title={t(item.title)}
+							placement="right"
+							color="violet"
+							tooltipDelay={{ open: 0, close: 50 }}
+							shouldShowTooltip={isShowTooltip}
 						>
-							<div className={styles.wrap}>
-								<ImageComponent className={styles.icon} />
-								<span className={classNames(styles.title)}>{t(item.title)}</span>
-							</div>
-						</NavLink>
+							<NavLink
+								key={index}
+								to={item.route}
+								end
+								className={classNames(styles.item, styles.nested, {
+									[styles.active]: isActiveItem,
+								})}
+							>
+								<div className={styles.wrap}>
+									<ImageComponent className={styles.icon} />
+									<span className={classNames(styles.title)}>{t(item.title)}</span>
+								</div>
+							</NavLink>
+						</Tooltip>
 					);
 				})}
 			</div>

--- a/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarMenuItem.tsx
+++ b/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarMenuItem.tsx
@@ -1,8 +1,3 @@
-import { useTranslation } from 'react-i18next';
-
-import { i18Namespace } from '@/shared/config/i18n';
-import { Tooltip } from '@/shared/ui/Tooltip';
-
 import { MenuItem } from '../../model/types/sidebar';
 
 import SidebarCategoryMenuItem from './SidebarCategoryMenuItem';
@@ -29,27 +24,22 @@ interface SidebarMenuItemProps {
  */
 
 export const SidebarMenuItem = ({ menuItem, fullWidth, isShowTooltip }: SidebarMenuItemProps) => {
-	const { t } = useTranslation(i18Namespace.translation);
-
-	const item = (() => {
-		switch (menuItem.type) {
-			case 'category':
-				return <SidebarCategoryMenuItem fullWidth={fullWidth} menuItem={menuItem} />;
-			case 'single':
-				return <SidebarSingleMenuItem fullWidth={fullWidth} menuItem={menuItem} />;
-		}
-	})();
-
-	return isShowTooltip ? (
-		<Tooltip
-			title={t(menuItem.title)}
-			placement="right"
-			color="violet"
-			tooltipDelay={{ open: 0, close: 50 }}
-		>
-			{item}
-		</Tooltip>
-	) : (
-		item
-	);
+	switch (menuItem.type) {
+		case 'category':
+			return (
+				<SidebarCategoryMenuItem
+					fullWidth={fullWidth}
+					menuItem={menuItem}
+					isShowTooltip={isShowTooltip}
+				/>
+			);
+		case 'single':
+			return (
+				<SidebarSingleMenuItem
+					fullWidth={fullWidth}
+					menuItem={menuItem}
+					isShowTooltip={isShowTooltip}
+				/>
+			);
+	}
 };

--- a/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarMenuItem.tsx
+++ b/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarMenuItem.tsx
@@ -1,3 +1,8 @@
+import { useTranslation } from 'react-i18next';
+
+import { i18Namespace } from '@/shared/config/i18n';
+import { Tooltip } from '@/shared/ui/Tooltip';
+
 import { MenuItem } from '../../model/types/sidebar';
 
 import SidebarCategoryMenuItem from './SidebarCategoryMenuItem';
@@ -12,20 +17,39 @@ interface SidebarMenuItemProps {
 	 * If set to true, the size of the menu item is full width, if set to false, the text is hidden and only the icon remains
 	 */
 	fullWidth: boolean;
+	isShowTooltip?: boolean;
 }
 
 /**
  * Element of sidebar menu list
  * @param menuItem
  * @param fullWidth
+ * @param isShowTooltip
  * @constructor
  */
 
-export const SidebarMenuItem = ({ menuItem, fullWidth }: SidebarMenuItemProps) => {
-	switch (menuItem.type) {
-		case 'category':
-			return <SidebarCategoryMenuItem fullWidth={fullWidth} menuItem={menuItem} />;
-		case 'single':
-			return <SidebarSingleMenuItem fullWidth={fullWidth} menuItem={menuItem} />;
-	}
+export const SidebarMenuItem = ({ menuItem, fullWidth, isShowTooltip }: SidebarMenuItemProps) => {
+	const { t } = useTranslation(i18Namespace.translation);
+
+	const item = (() => {
+		switch (menuItem.type) {
+			case 'category':
+				return <SidebarCategoryMenuItem fullWidth={fullWidth} menuItem={menuItem} />;
+			case 'single':
+				return <SidebarSingleMenuItem fullWidth={fullWidth} menuItem={menuItem} />;
+		}
+	})();
+
+	return isShowTooltip ? (
+		<Tooltip
+			title={t(menuItem.title)}
+			placement="right"
+			color="violet"
+			tooltipDelay={{ open: 0, close: 50 }}
+		>
+			{item}
+		</Tooltip>
+	) : (
+		item
+	);
 };

--- a/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarSingleMenuItem.tsx
+++ b/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarSingleMenuItem.tsx
@@ -5,6 +5,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { i18Namespace } from '@/shared/config/i18n';
 import { ROUTES } from '@/shared/config/router/routes';
 import { useScreenSize } from '@/shared/hooks';
+import { Tooltip } from '@/shared/ui/Tooltip';
 import { isPathMatch } from '@/shared/utils/isPathMatch';
 
 import { SingleMenuItem } from '../../model/types/sidebar';
@@ -14,9 +15,14 @@ import styles from './SidebarMenuItem.module.css';
 interface SidebarSingleMenuItemProps {
 	menuItem: SingleMenuItem;
 	fullWidth: boolean;
+	isShowTooltip?: boolean;
 }
 
-const SidebarSingleMenuItem = ({ fullWidth, menuItem }: SidebarSingleMenuItemProps) => {
+const SidebarSingleMenuItem = ({
+	fullWidth,
+	menuItem,
+	isShowTooltip,
+}: SidebarSingleMenuItemProps) => {
 	const ImageComponent = menuItem.icon;
 	const { isMobile, isTablet } = useScreenSize();
 	const location = useLocation();
@@ -28,29 +34,37 @@ const SidebarSingleMenuItem = ({ fullWidth, menuItem }: SidebarSingleMenuItemPro
 		return null;
 	}
 	return (
-		<NavLink
-			end
-			className={({ isActive }) =>
-				classNames(styles.item, {
-					[styles['admin-active']]: menuItem?.isAdmin,
-					[styles.active]: isActive || isActiveItem,
-					[styles.fullwidth]: fullWidth,
-				})
-			}
-			to={menuItem.route}
+		<Tooltip
+			title={t(menuItem.title)}
+			placement="right"
+			color="violet"
+			tooltipDelay={{ open: 0, close: 50 }}
+			shouldShowTooltip={isShowTooltip}
 		>
-			<div className={styles.container}>
-				<div className={styles.wrap}>
-					<ImageComponent className={styles.icon} />
-					<span className={classNames(styles.title)}>{t(menuItem.title)}</span>
+			<NavLink
+				end
+				className={({ isActive }) =>
+					classNames(styles.item, {
+						[styles['admin-active']]: menuItem?.isAdmin,
+						[styles.active]: isActive || isActiveItem,
+						[styles.fullwidth]: fullWidth,
+					})
+				}
+				to={menuItem.route}
+			>
+				<div className={styles.container}>
+					<div className={styles.wrap}>
+						<ImageComponent className={styles.icon} />
+						<span className={classNames(styles.title)}>{t(menuItem.title)}</span>
+					</div>
+					<div className={styles.side}>
+						{menuItem.notifications && (
+							<div className={styles.notifications}>{menuItem.notifications}</div>
+						)}
+					</div>
 				</div>
-				<div className={styles.side}>
-					{menuItem.notifications && (
-						<div className={styles.notifications}>{menuItem.notifications}</div>
-					)}
-				</div>
-			</div>
-		</NavLink>
+			</NavLink>
+		</Tooltip>
 	);
 };
 

--- a/src/widgets/Sidebar/ui/SidebarMenuList/SidebarMenuList.tsx
+++ b/src/widgets/Sidebar/ui/SidebarMenuList/SidebarMenuList.tsx
@@ -12,19 +12,26 @@ interface SidebarMenuListProps {
 	 * Sidebar menu items
 	 */
 	menuItems: MenuItem[];
+	isShowTooltip?: boolean;
 }
 
 /**
  * List of items for the sidebar menu
  * @param fullWidth
  * @param menuItems
+ * @param isShowTooltip
  * @constructor
  */
-export const SidebarMenuList = ({ fullWidth, menuItems }: SidebarMenuListProps) => {
+export const SidebarMenuList = ({ fullWidth, menuItems, isShowTooltip }: SidebarMenuListProps) => {
 	return (
 		<nav className={styles.nav} data-testid="SidebarMenuList">
 			{menuItems.map((menuItem, index) => (
-				<SidebarMenuItem key={index} fullWidth={fullWidth} menuItem={menuItem} />
+				<SidebarMenuItem
+					key={index}
+					fullWidth={fullWidth}
+					menuItem={menuItem}
+					isShowTooltip={isShowTooltip}
+				/>
 			))}
 		</nav>
 	);


### PR DESCRIPTION
Добавлена поддержка тултипов для пунктов меню в Sidebar, только для администраторов на десктопной версии сайта.
Использован уже существующий компонент Tooltip из shared/ui.
Логика отображения тултипов инкапсулирована внутри компонента SidebarMenuItem — тултип показывается при свернутом сайдбаре.