### PR TITLE
YH-1102: Marketplace – подключение API, пагинации и фильтров

### DIFF
--- a/src/entities/resource/api/resourceApi.ts
+++ b/src/entities/resource/api/resourceApi.ts
@@ -1,0 +1,20 @@
+import { ApiTags } from '@/shared/config/api/apiTags';
+import { baseApi } from '@/shared/config/api/baseApi';
+
+import { resourceApiUrls } from '../model/constants/resource';
+import { GetResourcesListParamsRequest, GetResourcesListResponse } from '../model/types/resource';
+
+const resourceApi = baseApi.injectEndpoints({
+	endpoints: (build) => ({
+		getResourcesList: build.query<GetResourcesListResponse, GetResourcesListParamsRequest>({
+			query: (params) => ({
+				url: resourceApiUrls.getResourcesList,
+				params: { page: 1, limit: 10, ...params },
+			}),
+			providesTags: [ApiTags.RESOURCES],
+		}),
+	}),
+});
+
+export const { useGetResourcesListQuery } = resourceApi;
+export type { GetResourcesListParamsRequest, GetResourcesListResponse };

--- a/src/entities/resource/index.ts
+++ b/src/entities/resource/index.ts
@@ -1,11 +1,12 @@
 export * from './model/types/resource';
 export * from './api/__mock__/data/resourcesMock';
 export * from './ui/ResourceCard/ResourceCard';
+export * from './api/resourceApi';
 
 export type {
-  FilterParams,
-  MarketplaceFilterStatus,
-  MarketplaceFilterStatusItem,
+	FilterParams,
+	MarketplaceFilterStatus,
+	MarketplaceFilterStatusItem,
 } from './model/types';
 export { StatusFilterSection } from './ui/StatusFilterSection/StatusFilterSection';
 export { KeywordsListSection } from './ui/KeywordsListSection/KeywordsListSection';

--- a/src/entities/resource/model/constants/resource.ts
+++ b/src/entities/resource/model/constants/resource.ts
@@ -1,3 +1,3 @@
 export const resourceApiUrls = {
-	getResourcesList: 'external-products',
+	getResourcesList: 'external-products/product',
 };

--- a/src/entities/resource/model/constants/resource.ts
+++ b/src/entities/resource/model/constants/resource.ts
@@ -1,0 +1,3 @@
+export const resourceApiUrls = {
+	getResourcesList: 'external-products',
+};

--- a/src/entities/resource/model/types/resource.ts
+++ b/src/entities/resource/model/types/resource.ts
@@ -1,12 +1,30 @@
+import { Response } from '@/shared/types/types';
+
+export type ResourceAccessCategory = 'free' | 'has_trial' | 'payed_only';
+
 export interface Resource {
 	id: string;
 	name: string;
 	provider: string;
 	iconBase64: string;
 	description: string;
-	accessCategory: string;
+	accessCategory: ResourceAccessCategory;
 	createdAt: string;
 	updatedAt: string;
 	isActive: boolean;
 	createdById: string;
 }
+
+export interface GetResourcesListParamsRequest {
+	page?: number;
+	limit?: number;
+	name?: string;
+	provider?: string;
+	accessCategory?: ResourceAccessCategory;
+	authorId?: string;
+	orderBy?: string;
+	order?: 'ASC' | 'DESC';
+	random?: boolean;
+}
+
+export type GetResourcesListResponse = Response<Resource[]>;

--- a/src/pages/landing/PublicMarketplacePage/ui/PublicMarketplacePage.tsx
+++ b/src/pages/landing/PublicMarketplacePage/ui/PublicMarketplacePage.tsx
@@ -45,6 +45,7 @@ const PublicMarketplacePage = () => {
 	} = useGetResourcesListQuery({
 		page: filter.page ?? 1,
 		limit: RESOURCES_PER_PAGE,
+		name: filter.title,
 	});
 
 	const resources = resourcesResponse?.data ?? [];

--- a/src/pages/landing/PublicMarketplacePage/ui/PublicMarketplacePage.tsx
+++ b/src/pages/landing/PublicMarketplacePage/ui/PublicMarketplacePage.tsx
@@ -12,9 +12,11 @@ import { IconButton } from '@/shared/ui/IconButton';
 import { Text } from '@/shared/ui/Text';
 import { toast } from '@/shared/ui/Toast';
 
-import { ResourcesList } from '@/widgets/Marketplace';
-
-import { MarketplaceFiltersPanel, useMarketplaceFilters } from '@/widgets/Marketplace';
+import {
+	ResourcesList,
+	MarketplaceFiltersPanel,
+	useMarketplaceFilters,
+} from '@/widgets/Marketplace';
 
 import styles from './PublicMarketplacePage.module.css';
 
@@ -73,7 +75,7 @@ const PublicMarketplacePage = () => {
 	const suggestButton = (
 		<Button
 			variant="link-purple"
-			suffix={<Icon icon="plus" />} // сюда «внёс» вашу иконку
+			suffix={<Icon icon="plus" />}
 			onClick={() => toast.success('Фича в разработке')}
 		>
 			{t(Marketplace.LINK_LABEL)}

--- a/src/pages/landing/PublicMarketplacePage/ui/PublicMarketplacePage.tsx
+++ b/src/pages/landing/PublicMarketplacePage/ui/PublicMarketplacePage.tsx
@@ -14,12 +14,16 @@ import { toast } from '@/shared/ui/Toast';
 
 import { useGetResourcesListQuery } from '@/entities/resource';
 
-import { ResourcesList } from '@/widgets/Marketplace';
-import { MarketplaceFiltersPanel, useMarketplaceFilters } from '@/widgets/Marketplace';
+import {
+	ResourcesList,
+	MarketplaceFiltersPanel,
+	useMarketplaceFilters,
+	ResourcesPagination,
+} from '@/widgets/Marketplace';
 
 import styles from './PublicMarketplacePage.module.css';
 
-const RESOURCES_PER_PAGE = 12;
+const RESOURCES_PER_PAGE = 6;
 
 const PublicMarketplacePage = () => {
 	const { isOpen, onToggle, onClose } = useModal();
@@ -31,6 +35,7 @@ const PublicMarketplacePage = () => {
 		onChangeResources,
 		onChangeStatus,
 		filter,
+		onPageChange,
 	} = useMarketplaceFilters();
 
 	const {
@@ -114,9 +119,13 @@ const PublicMarketplacePage = () => {
 						{suggestButton}
 					</Flex>
 				</Flex>
-				{/* список ресурсов: пока пустышка */}
 				<ResourcesList resources={resources} />
 
+				<ResourcesPagination
+					resourcesResponse={resourcesResponse}
+					currentPage={filter.page ?? 1}
+					onPageChange={onPageChange}
+				/>
 				{/* бургер виден только при ширине ≤ 1023 px */}
 			</Card>
 

--- a/src/pages/landing/PublicMarketplacePage/ui/PublicMarketplacePage.tsx
+++ b/src/pages/landing/PublicMarketplacePage/ui/PublicMarketplacePage.tsx
@@ -12,13 +12,14 @@ import { IconButton } from '@/shared/ui/IconButton';
 import { Text } from '@/shared/ui/Text';
 import { toast } from '@/shared/ui/Toast';
 
-import {
-	ResourcesList,
-	MarketplaceFiltersPanel,
-	useMarketplaceFilters,
-} from '@/widgets/Marketplace';
+import { useGetResourcesListQuery } from '@/entities/resource';
+
+import { ResourcesList } from '@/widgets/Marketplace';
+import { MarketplaceFiltersPanel, useMarketplaceFilters } from '@/widgets/Marketplace';
 
 import styles from './PublicMarketplacePage.module.css';
+
+const RESOURCES_PER_PAGE = 12;
 
 const PublicMarketplacePage = () => {
 	const { isOpen, onToggle, onClose } = useModal();
@@ -32,7 +33,26 @@ const PublicMarketplacePage = () => {
 		filter,
 	} = useMarketplaceFilters();
 
+	const {
+		data: resourcesResponse,
+		isFetching,
+		error,
+	} = useGetResourcesListQuery({
+		page: filter.page ?? 1,
+		limit: RESOURCES_PER_PAGE,
+	});
+
+	const resources = resourcesResponse?.data ?? [];
+
 	const { t } = useTranslation(i18Namespace.marketplace);
+
+	if (isFetching && !resourcesResponse) {
+		return <div>Loading…</div>;
+	}
+
+	if (error) {
+		return <div>Не удалось загрузить ресурсы</div>;
+	}
 
 	const renderFilters = () => (
 		<MarketplaceFiltersPanel
@@ -95,7 +115,7 @@ const PublicMarketplacePage = () => {
 					</Flex>
 				</Flex>
 				{/* список ресурсов: пока пустышка */}
-				<ResourcesList />
+				<ResourcesList resources={resources} />
 
 				{/* бургер виден только при ширине ≤ 1023 px */}
 			</Card>

--- a/src/shared/config/api/apiTags.ts
+++ b/src/shared/config/api/apiTags.ts
@@ -5,6 +5,7 @@ export enum ApiTags {
 	QUESTIONS_LEARNED = 'question_learned',
 	QUESTIONS = 'questions',
 	COLLECTIONS = 'collections',
+	RESOURCES = 'resources',
 	COLLECTION_DETAIL = 'collection_detail',
 	SKILLS = 'skills',
 	USERS = 'users',

--- a/src/widgets/Marketplace/index.ts
+++ b/src/widgets/Marketplace/index.ts
@@ -1,3 +1,4 @@
 export * from './ui/RecourcesList/ResourcesList';
+export * from './ui/ResourcesPagination/ResourcesPagination';
 export { MarketplaceFiltersPanel } from './ui/MarketplaceFiltersPanel/MarketplaceFiltersPanel';
 export { useMarketplaceFilters } from './model/hooks/useMarketplaceFilters';

--- a/src/widgets/Marketplace/model/hooks/useMarketplaceFilters.ts
+++ b/src/widgets/Marketplace/model/hooks/useMarketplaceFilters.ts
@@ -28,6 +28,10 @@ export const useMarketplaceFilters = () => {
 		handleFilterChange({ status });
 	};
 
+	const onPageChange = (page: number) => {
+		handleFilterChange({ page });
+	};
+
 	return {
 		filter,
 		onChangeSearchParams,
@@ -35,6 +39,7 @@ export const useMarketplaceFilters = () => {
 		onChangeResources,
 		onChangeSpecialization,
 		onChangeStatus,
+		onPageChange,
 		resetFilters,
 	};
 };

--- a/src/widgets/Marketplace/ui/ResourcesPagination/ResourcesPagination.module.css
+++ b/src/widgets/Marketplace/ui/ResourcesPagination/ResourcesPagination.module.css
@@ -1,0 +1,18 @@
+.wrapper {
+  display: flex;
+  justify-content: center;
+  margin: 40px 0 16px;
+}
+
+@media (width <= 768px) {
+  .wrapper {
+    margin-top: 30px;
+  }
+}
+
+@media (width <= 368px) {
+  .wrapper {
+    margin-top: 40px;
+    margin-bottom: 0;
+  }
+}

--- a/src/widgets/Marketplace/ui/ResourcesPagination/ResourcesPagination.tsx
+++ b/src/widgets/Marketplace/ui/ResourcesPagination/ResourcesPagination.tsx
@@ -1,0 +1,38 @@
+import { Response } from '@/shared/types/types';
+import { Pagination } from '@/shared/ui/Pagination';
+
+import { Resource } from '@/entities/resource';
+
+import styles from './ResourcesPagination.module.css';
+
+interface ResourcesPaginationProps {
+	resourcesResponse?: Response<Resource[]>;
+	currentPage: number;
+	onPageChange: (page: number) => void;
+}
+
+export const ResourcesPagination = ({
+	resourcesResponse,
+	currentPage,
+	onPageChange,
+}: ResourcesPaginationProps) => {
+	if (!resourcesResponse?.data?.length) return null;
+
+	const totalPages = Math.ceil(resourcesResponse.total / resourcesResponse.limit);
+
+	const handlePrev = () => onPageChange(currentPage - 1);
+	const handleNext = () => onPageChange(currentPage + 1);
+	const handleButton = (page: number) => onPageChange(page);
+
+	return (
+		<div className={styles.wrapper}>
+			<Pagination
+				onPrevPageClick={handlePrev}
+				onNextPageClick={handleNext}
+				onChangePage={handleButton}
+				page={currentPage}
+				totalPages={totalPages}
+			/>
+		</div>
+	);
+};


### PR DESCRIPTION
- Подключён реальный эндпоинт GET /external-products/product вместо моков.
- Добавлен компонент ResourcesPagination, хранение page через useMarketplaceFilters
- Подключён поиск по названию, остальные фильтры не подключены, т.к:
В дизайне присутствуют specialization, skills, resources, status, а в swagger-контракте сейчас доступны только name и accessCategory, кроме того accessCategory отсутствует в макете. 

Проблему описал бэку, они приняли в работу, будут исправлять, Руслан сказал пока открывать PR с тем, что имеется, т.к. исправлений у них будет много.
