### PR TITLE
YH-1207: fix login error toast

### DIFF
--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -126,14 +126,14 @@
 			},
 			"login": {
 				"failed": "Неверный email или пароль."
-			}
-		},
-		"user": {
-			"email": {
-				"not_exist": "Пользователя с таким email не существует."
 			},
-			"password": {
-				"wrong": "Неверный пароль."
+			"user": {
+				"email": {
+					"not_exist": "Пользователя с таким email не существует."
+				},
+				"password": {
+					"wrong": "Неверный пароль."
+				}
 			}
 		},
 		"questions": {


### PR DESCRIPTION
Не работал перевод при неправильном email в форме логина. Ключ с бекенда приходил не такой как в переводах, перенес на уровень ниже user перевод и всё заработало нормально.