### PR TITLE
YH-1233: quiz results without subscription

### DIFF
--- a/src/pages/interview/CreateQuizPage/model/hooks/useCalculationInterviewResult.ts
+++ b/src/pages/interview/CreateQuizPage/model/hooks/useCalculationInterviewResult.ts
@@ -1,0 +1,44 @@
+import { Quiz, Answers } from '@/entities/quiz';
+
+export interface ProfileSkillsStat {
+	skillStat: {
+		fullSkillsQuestionsMap: { skill: string; count: number }[];
+		learnedSkillsQuestionsMap: { skill: string; count: number }[];
+	};
+}
+export const useCalculationInterviewResult = (
+	quiz?: Quiz,
+	questions?: Answers[],
+): ProfileSkillsStat => {
+	if (!quiz) {
+		return {
+			skillStat: {
+				fullSkillsQuestionsMap: [],
+				learnedSkillsQuestionsMap: [],
+			},
+		};
+	}
+
+	const fullSkillsQuestionsMap = quiz.skills.map((skill) => ({
+		skill: skill,
+		count: quiz.questions.filter((q) => q.questionSkills.some((qs) => qs.title === skill)).length,
+	}));
+
+	const knownAnswers = questions?.filter((el) => el.answer === 'KNOWN') || [];
+
+	const learnedSkillsQuestionsMap = quiz.skills.map((skill) => ({
+		skill: skill,
+		count: quiz.questions.filter(
+			(q) =>
+				q.questionSkills.some((qs) => qs.title === skill) &&
+				knownAnswers.some((a) => a.questionId === q.id),
+		).length,
+	}));
+
+	return {
+		skillStat: {
+			fullSkillsQuestionsMap,
+			learnedSkillsQuestionsMap,
+		},
+	};
+};

--- a/src/pages/interview/InterviewQuizResultPage/ui/InterviewQuizResultPage.tsx
+++ b/src/pages/interview/InterviewQuizResultPage/ui/InterviewQuizResultPage.tsx
@@ -1,10 +1,13 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
+import { i18Namespace } from '@/shared/config/i18n';
+import { InterviewStatistics } from '@/shared/config/i18n/i18nTranslations';
 import { useAppSelector } from '@/shared/hooks';
 import { Flex } from '@/shared/ui/Flex';
 
-import { getProfileId } from '@/entities/profile';
+import { getHasPremiumAccess, getProfileId } from '@/entities/profile';
 import {
 	useGetActiveQuizQuery,
 	useGetQuizByProfileIdQuery,
@@ -13,18 +16,24 @@ import {
 
 import { ResetActiveQuizModal } from '@/features/quiz/resetActiveQuizModal';
 
+import { CategoryProgressList } from '@/widgets/interview/CategoryProgressList';
 import { PassedQuestionsList } from '@/widgets/interview/PassedQuestionsList';
 import { QuizAdditionalInfo } from '@/widgets/interview/QuizAdditionalInfo';
 import { QuizQuestionsInfo } from '@/widgets/interview/QuizzesStatistic';
 
 import { InterviewQuizResultPageSkeleton } from '@/pages/interview/InterviewQuizResultPage';
 
+import { useCalculationInterviewResult } from '../../CreateQuizPage/model/hooks/useCalculationInterviewResult';
+
 import styles from './InterviewQuizResultPage.module.css';
 
 const InterviewQuizResultPage = () => {
+	const { t } = useTranslation(i18Namespace.interviewStatistics);
 	const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
 
 	const profileId = useAppSelector(getProfileId);
+	const hasPremium = useAppSelector(getHasPremiumAccess);
+
 	const { quizId } = useParams<{ quizId?: string }>();
 
 	const [cloneQuiz] = useLazyCloneQuizQuery();
@@ -33,6 +42,9 @@ const InterviewQuizResultPage = () => {
 		quizId: quizId ?? '',
 		profileId,
 	});
+
+	const questions = quiz?.response.answers;
+	const interviewResult = useCalculationInterviewResult(quiz, questions);
 
 	const { data: activeQuizResponse } = useGetActiveQuizQuery({
 		profileId,
@@ -44,8 +56,6 @@ const InterviewQuizResultPage = () => {
 	if (isLoading) {
 		return <InterviewQuizResultPageSkeleton />;
 	}
-
-	const questions = quiz?.response.answers;
 
 	function handleCloneQuiz() {
 		if (!activeQuiz) {
@@ -66,12 +76,21 @@ const InterviewQuizResultPage = () => {
 	return (
 		<>
 			<Flex gap="20" wrap="wrap" className={styles.container}>
-				<QuizQuestionsInfo
-					className={styles.questions}
-					questions={questions}
-					quizNumber={quiz?.quizNumber}
-				/>
+				{hasPremium && (
+					<QuizQuestionsInfo
+						className={styles.questions}
+						questions={questions}
+						quizNumber={quiz?.quizNumber}
+					/>
+				)}
 				<QuizAdditionalInfo className={styles.quiz} quiz={quiz} isLoading={isLoading} />
+				{!hasPremium && (
+					<CategoryProgressList
+						title={t(InterviewStatistics.PROGRESS_TITLE)}
+						className={styles.questions}
+						skillsStat={interviewResult?.skillStat}
+					/>
+				)}
 				<PassedQuestionsList
 					className={styles['questions-list']}
 					questions={questions ?? []}

--- a/src/pages/landing/CreatePublicQuizPage/ui/CreatePublicQuizPage.tsx
+++ b/src/pages/landing/CreatePublicQuizPage/ui/CreatePublicQuizPage.tsx
@@ -9,7 +9,7 @@ import {
 	DEFAULT_SPECIALIZATION_NUMBER,
 	MAX_CHOOSE_QUESTION_COUNT,
 } from '@/shared/constants/queryConstants';
-import { getFromLS, setToLS } from '@/shared/helpers/manageLocalStorage';
+import { setToLS } from '@/shared/helpers/manageLocalStorage';
 import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { Button } from '@/shared/ui/Button';
 import { Card } from '@/shared/ui/Card';
@@ -141,7 +141,7 @@ const CreatePublicQuizPage = () => {
 							disabled={true}
 							active={true}
 						/>
-						<ChooseQuestionCount 
+						<ChooseQuestionCount
 							onChangeLimit={onChangeLimit}
 							count={filter.count || 1}
 							maxCount={MAX_CHOOSE_QUESTION_COUNT}

--- a/src/widgets/interview/QuizAdditionalInfo/ui/QuizAdditionalInfo/QuizAdditionalInfo.tsx
+++ b/src/widgets/interview/QuizAdditionalInfo/ui/QuizAdditionalInfo/QuizAdditionalInfo.tsx
@@ -18,7 +18,7 @@ export interface QuizAdditionalInfoProps {
 export const QuizAdditionalInfo = ({ className, quiz, isLoading }: QuizAdditionalInfoProps) => {
 	const { t } = useTranslation(i18Namespace.interviewQuizResult);
 
-	const learnedQuestions = (quiz?.questions || []).filter((question) => question.isLearned).length;
+	const learnedQuestions = quiz?.response.answers.filter((e) => e.answer === 'KNOWN').length;
 
 	const questionStats = [
 		{


### PR DESCRIPTION
### Отображение результатов квиза для пользователя без подписки

1. Отображение компонентов статистики в зависимости от наличия подписки
2. Добавлен хук useCalculationInterviewResult для конвертирования данных и подсчета показателей существующих навыков
3. Изменена логика подсчета пройденных вопросов learnedQuestions (отображалось неверно)