### PR TITLE
YH-1224: Add mock quiz for users without subscription

### DIFF
--- a/src/app/providers/router/config/routeConfig.tsx
+++ b/src/app/providers/router/config/routeConfig.tsx
@@ -574,9 +574,7 @@ export const router = createBrowserRouter([
 						path: ROUTES.interview.new.route,
 						element: (
 							<VerifiedEmailRoute>
-								<PremiumRoute>
-									<InterviewQuizPage />
-								</PremiumRoute>
+								<InterviewQuizPage />
 							</VerifiedEmailRoute>
 						),
 						handle: {

--- a/src/entities/quiz/api/quizApi.ts
+++ b/src/entities/quiz/api/quizApi.ts
@@ -11,7 +11,11 @@ import { toast } from '@/shared/ui/Toast';
 
 import { getValidActiveQuizzesFromLS } from '@/entities/quiz/model/helpers/getValidActiveQuizzesFromLS';
 
-import { LS_ACTIVE_MOCK_QUIZ_KEY, quizApiUrls } from '../model/constants/quizConstants';
+import {
+	LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY,
+	LS_ACTIVE_MOCK_QUIZ_KEY,
+	quizApiUrls,
+} from '../model/constants/quizConstants';
 import { clearActiveQuizState, setActiveQuizQuestions } from '../model/slices/activeQuizSlice';
 import {
 	CreateNewQuizParamsRequest,
@@ -69,6 +73,31 @@ const quizApi = baseApi.injectEndpoints({
 				try {
 					const { data: mockQuizResponse } = await queryFulfilled;
 					mockQuizResponse && setToLS(LS_ACTIVE_MOCK_QUIZ_KEY, mockQuizResponse);
+					const typedExtra = extra as ExtraArgument;
+					toast.success(i18n.t(Translation.TOAST_INTERVIEW_NEW_QUIZ_SUCCESS));
+					typedExtra.navigate(ROUTES.interview.new.page);
+					dispatch(baseApi.util.invalidateTags([ApiTags.HISTORY_QUIZ, ApiTags.INTERVIEW_QUIZ]));
+				} catch (error) {
+					toast.error(i18n.t(Translation.TOAST_INTERVIEW_NEW_QUIZ_FAILED));
+					console.error(error);
+				}
+			},
+		}),
+		createNewMockPublicQuiz: build.query<
+			Response<CreateNewMockQuizResponse>,
+			CreateNewMockQuizParamsRequest
+		>({
+			query: ({ ...params }) => {
+				return {
+					url: route(quizApiUrls.createNewMockQuiz),
+					params,
+				};
+			},
+			providesTags: [ApiTags.NEW_QUIZ],
+			async onQueryStarted(_, { queryFulfilled, extra, dispatch }) {
+				try {
+					const { data: mockQuizResponse } = await queryFulfilled;
+					mockQuizResponse && setToLS(LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY, mockQuizResponse);
 					const typedExtra = extra as ExtraArgument;
 					toast.success(i18n.t(Translation.TOAST_INTERVIEW_NEW_QUIZ_SUCCESS));
 					typedExtra.navigate(ROUTES.quiz.new.page);
@@ -240,6 +269,7 @@ const quizApi = baseApi.injectEndpoints({
 
 export const {
 	useLazyCreateNewQuizQuery,
+	useLazyCreateNewMockPublicQuizQuery,
 	useLazyCreateNewMockQuizQuery,
 	useGetActiveQuizQuery,
 	useGetHistoryQuizQuery,

--- a/src/entities/quiz/hooks/useSlideSwitcher.ts
+++ b/src/entities/quiz/hooks/useSlideSwitcher.ts
@@ -5,7 +5,7 @@ import { matchPath, useLocation } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '@/shared/hooks';
 
 // eslint-disable-next-line @conarti/feature-sliced/layers-slices
-import { getProfileId } from '@/entities/profile';
+import { getHasPremiumAccess, getProfileId } from '@/entities/profile';
 
 import { changeQuestionAnswer } from '../model/slices/activeQuizSlice';
 import { Answers, QuizQuestionAnswerType } from '../model/types/quiz';
@@ -15,6 +15,7 @@ export const useSlideSwitcher = (questions: Answers[]) => {
 
 	const dispatch = useAppDispatch();
 	const profileId = useAppSelector(getProfileId);
+	const hasPremium = useAppSelector(getHasPremiumAccess);
 	const location = useLocation();
 
 	const answeredCount = questions.filter((question) => question.answer !== undefined).length;
@@ -27,6 +28,7 @@ export const useSlideSwitcher = (questions: Answers[]) => {
 				answer,
 				shouldSaveToLS: isAuthRoute,
 				profileId,
+				hasPremium,
 			}),
 		);
 	};

--- a/src/entities/quiz/index.ts
+++ b/src/entities/quiz/index.ts
@@ -5,6 +5,7 @@ export { useSlideSwitcher } from '../quiz/hooks/useSlideSwitcher';
 
 export {
 	useLazyCreateNewQuizQuery,
+	useLazyCreateNewMockPublicQuizQuery,
 	useLazyCreateNewMockQuizQuery,
 	useGetActiveQuizQuery,
 	useGetHistoryQuizQuery,
@@ -36,8 +37,16 @@ export {
 	getLastActiveQuizInfo,
 } from './model/selectors/quizSelectors';
 
-export { activeQuizSlice, setActiveQuizQuestions } from './model/slices/activeQuizSlice';
+export {
+	activeQuizSlice,
+	setActiveQuizQuestions,
+	clearActiveQuizState,
+} from './model/slices/activeQuizSlice';
 
-export { LS_ACTIVE_QUIZZES_KEY, LS_ACTIVE_MOCK_QUIZ_KEY } from './model/constants/quizConstants';
+export {
+	LS_ACTIVE_QUIZZES_KEY,
+	LS_ACTIVE_MOCK_QUIZ_KEY,
+	LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY,
+} from './model/constants/quizConstants';
 
 export { interviewHandlers } from './api/__mocks__/index';

--- a/src/entities/quiz/model/constants/quizConstants.ts
+++ b/src/entities/quiz/model/constants/quizConstants.ts
@@ -1,5 +1,6 @@
 export const LS_ACTIVE_QUIZZES_KEY = 'activeQuizzes';
 export const LS_ACTIVE_MOCK_QUIZ_KEY = 'activeMockQuiz';
+export const LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY = 'activeMockPublicQuiz';
 
 export const quizApiUrls = {
 	createNewQuiz: 'interview-preparation/quizzes/new/:profileId',

--- a/src/entities/quiz/model/slices/activeQuizSlice.ts
+++ b/src/entities/quiz/model/slices/activeQuizSlice.ts
@@ -5,7 +5,7 @@ import { setToLS } from '@/shared/helpers/manageLocalStorage';
 
 import { getValidActiveQuizzesFromLS } from '@/entities/quiz/model/helpers/getValidActiveQuizzesFromLS';
 
-import { LS_ACTIVE_QUIZZES_KEY } from '../constants/quizConstants';
+import { LS_ACTIVE_MOCK_QUIZ_KEY, LS_ACTIVE_QUIZZES_KEY } from '../constants/quizConstants';
 import { updateQuestionAnswer } from '../helpers/updateQuestionAnswer';
 import { ActiveQuizState, Answers, ChangeQuestionAnswerParams } from '../types/quiz';
 
@@ -32,18 +32,23 @@ export const activeQuizSlice = createSlice({
 			}
 		},
 		changeQuestionAnswer: (state, action: PayloadAction<ChangeQuestionAnswerParams>) => {
-			const { shouldSaveToLS, profileId } = action.payload;
+			const { shouldSaveToLS, profileId, hasPremium = true } = action.payload;
 			state.questions = updateQuestionAnswer(state.questions, action.payload);
 			if (shouldSaveToLS && profileId) {
-				const { quizzes } = getValidActiveQuizzesFromLS();
-				setToLS(LS_ACTIVE_QUIZZES_KEY, { ...(quizzes || {}), [profileId]: state.questions });
+				if (hasPremium) {
+					const { quizzes } = getValidActiveQuizzesFromLS();
+					quizzes &&
+						setToLS(LS_ACTIVE_QUIZZES_KEY, { ...(quizzes || {}), [profileId]: state.questions });
+				} else {
+					setToLS(LS_ACTIVE_MOCK_QUIZ_KEY, state.questions);
+				}
 			}
 		},
 		clearActiveQuizState: (state, action: PayloadAction<string>) => {
 			state.questions = [];
 			const { quizzes } = getValidActiveQuizzesFromLS();
 			quizzes && delete quizzes[action.payload];
-			setToLS(LS_ACTIVE_QUIZZES_KEY, { ...(quizzes || {}) });
+			quizzes && setToLS(LS_ACTIVE_QUIZZES_KEY, { ...(quizzes || {}) });
 		},
 	},
 	extraReducers: (builder) => {

--- a/src/entities/quiz/model/types/quiz.ts
+++ b/src/entities/quiz/model/types/quiz.ts
@@ -31,7 +31,7 @@ export interface Answers {
 	answer: QuizQuestionAnswerType;
 	imageSrc?: string;
 	shortAnswer: string;
-	isFavorite: boolean;
+	isFavorite?: boolean;
 }
 
 export interface ActiveQuizState {
@@ -43,6 +43,7 @@ export interface ChangeQuestionAnswerParams {
 	profileId: string;
 	answer: QuizQuestionAnswerType;
 	shouldSaveToLS?: boolean;
+	hasPremium?: boolean;
 }
 
 export interface ProgressByCategoriesData {
@@ -93,7 +94,7 @@ export type interruptQuizRequest = {
 
 export interface CreateNewMockQuizParamsRequest
 	extends Omit<CreateNewQuizParamsRequest, 'profileId'> {
-	specialization?: number[];
+	specialization?: number[] | number;
 }
 
 export type CreateNewMockQuizResponse = Omit<CreateNewQuizResponse, 'profileId'>;

--- a/src/pages/interview/CreateQuizPage/ui/CreateQuizPage.tsx
+++ b/src/pages/interview/CreateQuizPage/ui/CreateQuizPage.tsx
@@ -21,6 +21,7 @@ import {
 	QuestionModeType,
 	QuizQuestionMode,
 	useGetActiveQuizQuery,
+	useLazyCreateNewMockQuizQuery,
 	useLazyCreateNewQuizQuery,
 } from '@/entities/quiz';
 import { useGetSkillsListQuery } from '@/entities/skill';
@@ -48,17 +49,22 @@ const CreateQuizPage = () => {
 
 	const navigate = useNavigate();
 
-	const { data: activeQuizData, isLoading: isActiveQuizLoading } = useGetActiveQuizQuery({
-		profileId,
-		limit: 1,
-		page: 1,
-	});
+	const { data: activeQuizData, isLoading: isActiveQuizLoading } = useGetActiveQuizQuery(
+		{
+			profileId,
+			limit: 1,
+			page: 1,
+		},
+		{ skip: !hasPremium },
+	);
 
 	if (activeQuizData?.data[0]?.questions) {
 		navigate(ROUTES.interview.new.page);
 	}
 
 	const [createNewQuiz, { isLoading: isCreateNewQuizLoading }] = useLazyCreateNewQuizQuery();
+	const [createNewMockQuiz, { isLoading: isCreateNewMockQuizLoading }] =
+		useLazyCreateNewMockQuizQuery();
 
 	const onChangeSkills = (skills?: number[]) => {
 		handleFilterChange({ category: skills });
@@ -83,6 +89,14 @@ const CreateQuizPage = () => {
 			complexity: filter.complexity,
 			limit: filter.count,
 			mode: filter.mode,
+		});
+	};
+
+	const onCreateNewMockQuiz = () => {
+		createNewMockQuiz({
+			skills: filter.category,
+			limit: filter.count || 1,
+			specialization: profileSpecialization,
 		});
 	};
 
@@ -130,9 +144,9 @@ const CreateQuizPage = () => {
 				</Flex>
 				<Button
 					className={styles.button}
-					onClick={onCreateNewQuiz}
+					onClick={hasPremium ? onCreateNewQuiz : onCreateNewMockQuiz}
 					suffix={<Icon icon="arrowRight" size={24} />}
-					disabled={isCreateNewQuizLoading}
+					disabled={hasPremium ? isCreateNewQuizLoading : isCreateNewMockQuizLoading}
 				>
 					{t(InterviewQuizCreate.CREATE_BUTTON)}
 				</Button>

--- a/src/pages/landing/CreatePublicQuizPage/ui/CreatePublicQuizPage.tsx
+++ b/src/pages/landing/CreatePublicQuizPage/ui/CreatePublicQuizPage.tsx
@@ -9,7 +9,7 @@ import {
 	DEFAULT_SPECIALIZATION_NUMBER,
 	MAX_CHOOSE_QUESTION_COUNT,
 } from '@/shared/constants/queryConstants';
-import { getFromLS, setToLS } from '@/shared/helpers/manageLocalStorage';
+import { setToLS } from '@/shared/helpers/manageLocalStorage';
 import { useScreenSize } from '@/shared/hooks/useScreenSize';
 import { Button } from '@/shared/ui/Button';
 import { Card } from '@/shared/ui/Card';
@@ -23,7 +23,11 @@ import {
 	ChooseQuestionsCategories,
 	ChooseSpecialization,
 } from '@/entities/question';
-import { QuestionModeType, QuizQuestionMode, useLazyCreateNewMockQuizQuery } from '@/entities/quiz';
+import {
+	QuestionModeType,
+	QuizQuestionMode,
+	useLazyCreateNewMockPublicQuizQuery,
+} from '@/entities/quiz';
 import { useGetSkillsListQuery } from '@/entities/skill';
 import { LS_ACTIVE_SPECIALIZATION_ID } from '@/entities/specialization';
 
@@ -40,7 +44,7 @@ const CreatePublicQuizPage = () => {
 
 	const { filter, handleFilterChange } = useQueryFilter();
 	const [createNewMockQuiz, { isLoading: isCreateNewMockQuizLoading }] =
-		useLazyCreateNewMockQuizQuery();
+		useLazyCreateNewMockPublicQuizQuery();
 
 	const { isLoading: isLoadingCategories } = useGetSkillsListQuery({
 		limit: MAX_LIMIT_CATEGORIES,
@@ -141,7 +145,7 @@ const CreatePublicQuizPage = () => {
 							disabled={true}
 							active={true}
 						/>
-						<ChooseQuestionCount 
+						<ChooseQuestionCount
 							onChangeLimit={onChangeLimit}
 							count={filter.count || 1}
 							maxCount={MAX_CHOOSE_QUESTION_COUNT}

--- a/src/pages/landing/PublicQuizPage/ui/PublicQuizPage.tsx
+++ b/src/pages/landing/PublicQuizPage/ui/PublicQuizPage.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 // eslint-disable-next-line import/order
-import { QuestionNavPanel, useSlideSwitcher, LS_ACTIVE_MOCK_QUIZ_KEY } from '@/entities/quiz';
+import {
+	QuestionNavPanel,
+	useSlideSwitcher,
+	LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY,
+} from '@/entities/quiz';
 
 import { i18Namespace } from '@/shared/config/i18n';
 import { InterviewQuiz } from '@/shared/config/i18n/i18nTranslations';
@@ -30,7 +34,7 @@ const PublicQuizPage = () => {
 	const [isAnswerVisible, setIsAnswerVisible] = useState(false);
 	const { t } = useTranslation(i18Namespace.interviewQuiz);
 	const navigate = useNavigate();
-	const activeMockQuiz = getJSONFromLS(LS_ACTIVE_MOCK_QUIZ_KEY);
+	const activeMockQuiz = getJSONFromLS(LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY);
 	const isAllQuestionsAnswered = activeMockQuiz?.response.answers.every(
 		(question: Answers) => question.answer !== undefined && question.answer !== null,
 	);
@@ -94,14 +98,14 @@ const PublicQuizPage = () => {
 			...activeMockQuiz,
 			response: { ...activeMockQuiz.response, answers: updatedAnswers },
 		};
-		setToLS(LS_ACTIVE_MOCK_QUIZ_KEY, newMockData);
+		setToLS(LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY, newMockData);
 		forceUpdate();
 		changeAnswer(newAnswer);
 	};
 
 	const onInterruptQuiz = () => {
 		if (activeMockQuiz) {
-			removeFromLS(LS_ACTIVE_MOCK_QUIZ_KEY);
+			removeFromLS(LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY);
 			navigate(`${ROUTES.quiz.page}`);
 		}
 		removeFromLS(LS_ACTIVE_SPECIALIZATION_ID);

--- a/src/pages/landing/PublicQuizResultPage/model/hooks/useCalculationQuizResult.ts
+++ b/src/pages/landing/PublicQuizResultPage/model/hooks/useCalculationQuizResult.ts
@@ -1,7 +1,7 @@
 import { getJSONFromLS } from '@/shared/helpers/manageLocalStorage';
 
 import { GetQuestionsBySpecializationCountResponse } from '@/entities/question';
-import { LS_ACTIVE_MOCK_QUIZ_KEY, Quiz } from '@/entities/quiz';
+import { LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY, Quiz } from '@/entities/quiz';
 
 export interface ProfileSkillsStat {
 	skillStat: {
@@ -22,7 +22,7 @@ export const useCalculationQuizResult = (
 		};
 	}
 
-	const activeMockQuiz: Quiz = getJSONFromLS(LS_ACTIVE_MOCK_QUIZ_KEY);
+	const activeMockQuiz: Quiz = getJSONFromLS(LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY);
 	const learnedCount = activeMockQuiz.response.answers.filter((el) => el.answer === 'KNOWN');
 
 	const learnedMap = new Map(learnedCount.map((lq) => [lq.questionId, true]));

--- a/src/pages/landing/PublicQuizResultPage/model/hooks/usePublicQuizResultData.ts
+++ b/src/pages/landing/PublicQuizResultPage/model/hooks/usePublicQuizResultData.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { getJSONFromLS, removeFromLS } from '@/shared/helpers/manageLocalStorage';
 
-import { Answers, LS_ACTIVE_MOCK_QUIZ_KEY } from '@/entities/quiz';
+import { Answers, LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY } from '@/entities/quiz';
 import { LS_ACTIVE_SPECIALIZATION_ID } from '@/entities/specialization';
 
 export const usePublicQuizResultData = () => {
@@ -15,7 +15,7 @@ export const usePublicQuizResultData = () => {
 		let timer: ReturnType<typeof setTimeout>;
 
 		try {
-			const data = getJSONFromLS(LS_ACTIVE_MOCK_QUIZ_KEY);
+			const data = getJSONFromLS(LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY);
 			if (!data) {
 				navigate('/');
 				return;
@@ -37,7 +37,7 @@ export const usePublicQuizResultData = () => {
 
 	useEffect(() => {
 		return () => {
-			removeFromLS(LS_ACTIVE_MOCK_QUIZ_KEY);
+			removeFromLS(LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY);
 			removeFromLS(LS_ACTIVE_SPECIALIZATION_ID);
 		};
 	}, []);

--- a/src/widgets/interview/QuestionsStatistic/ui/PassedQuestionsStatistic/PassedQuestionsStatistic.tsx
+++ b/src/widgets/interview/QuestionsStatistic/ui/PassedQuestionsStatistic/PassedQuestionsStatistic.tsx
@@ -5,7 +5,7 @@ import { InterviewQuizResult } from '@/shared/config/i18n/i18nTranslations';
 import { getJSONFromLS } from '@/shared/helpers/manageLocalStorage';
 import { AdditionalStatInfoGauge } from '@/shared/ui/AdditionalStatInfoGauge';
 
-import { LS_ACTIVE_MOCK_QUIZ_KEY, Quiz } from '@/entities/quiz';
+import { LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY, Quiz } from '@/entities/quiz';
 
 import { getQuestionsStats } from '../../model/lib/getQuestionsStats/getQuestionsStats';
 
@@ -22,7 +22,7 @@ export const PassedQuestionsStatistic = ({
 }: PassedQuestionsStatisticProps) => {
 	const { t } = useTranslation(i18Namespace.interviewQuizResult);
 
-	const activeMockQuiz: Quiz = getJSONFromLS(LS_ACTIVE_MOCK_QUIZ_KEY);
+	const activeMockQuiz: Quiz = getJSONFromLS(LS_ACTIVE_MOCK_PUBLIC_QUIZ_KEY);
 	const inProcessCount = activeMockQuiz.response.answers.filter(
 		(el) => el.answer === 'UNKNOWN',
 	).length;


### PR DESCRIPTION
Запуск мок квиза для пользователей без подписки
1. добавила endpoint createNewMockQuiz для обработки мокового запроса
2. данные сохраняются в localStorage под ключем - activeMockQuiz и в сторе
3. изменила сохранение процесса прохождения публичного квиза, ключ - activeMockPublicQuiz 
