### PR TITLE
YH-1236: fix refresh

### DIFF
--- a/src/entities/auth/api/authApi.ts
+++ b/src/entities/auth/api/authApi.ts
@@ -29,8 +29,9 @@ export const authApi = baseApi.injectEndpoints({
 				method: 'POST',
 				body,
 			}),
-			async onQueryStarted(_, { queryFulfilled, extra }) {
+			async onQueryStarted(_, { queryFulfilled, extra, dispatch }) {
 				try {
+					dispatch(baseApi.util.resetApiState());
 					const result = await queryFulfilled;
 					setToLS(LS_ACCESS_TOKEN_KEY, result.data.access_token);
 					const typedExtra = extra as ExtraArgument;
@@ -93,8 +94,10 @@ export const authApi = baseApi.injectEndpoints({
 					removeFromLS(LS_ACCESS_TOKEN_KEY);
 					const typedExtra = extra as ExtraArgument;
 					typedExtra.navigate(ROUTES.auth.login.page);
-					dispatch(baseApi.util.resetApiState());
-					dispatch(clearStore());
+					setTimeout(() => {
+						dispatch(baseApi.util.resetApiState());
+						dispatch(clearStore());
+					}, 0);
 				} catch (error) {
 					// eslint-disable-next-line no-console
 					console.error(error);


### PR DESCRIPTION
resetApiState сбрасывал кеш всех запросов до того как размаунтится компонент, так что запрос шел заново, но уже без access_token, нашел два решения:
- timeot - не знаю кастыльно или норм
- просто не сбрасывать кеш при logout, он живет всего 60 секунд, так что есть вариант сбрасывать его при login
401 ошибку при logout так и не получилось поймать
нашел место, где происходит тройной рефреш, но не знаю, нужно ли это фиксить, т.к. изменения внесены 2 месяца назад, когда виталий тоже чинил refresh api.dispatch(apiAccessTokenIsBrokenEvent());