### PR TITLE
YH-1243: fix(styles): remove background-color: inherit in collection preview and fix duplicate :disabled selector in button

### DIFF
--- a/src/entities/collection/ui/CollectionPreview/CollectionPreview.module.css
+++ b/src/entities/collection/ui/CollectionPreview/CollectionPreview.module.css
@@ -66,7 +66,7 @@
   overflow: hidden;
   border-radius: 12px;
   place-content: center center;
-  background-color: inherit;
+
 
   &.row {
     width: 149px;

--- a/src/shared/ui/Button/Button.module.css
+++ b/src/shared/ui/Button/Button.module.css
@@ -212,14 +212,6 @@
   &:disabled {
     color: var(--button-text-color-tertiary-disabled);
   }
-	
-  &:not([disabled]):hover {
-    color: var(--color-purple-700);
-  }
-
-  &:disabled {
-    color: var(--button-text-color-tertiary-disabled);
-  }
 
   &:disabled:hover {
     background-color: inherit;
@@ -227,6 +219,10 @@
 
   &:disabled:active {
     background-color: inherit;
+  }
+
+  &:not([disabled]):hover {
+    color: var(--color-purple-700);
   }
 }
 


### PR DESCRIPTION
https://tracker.yandex.ru/YH-1243/fields

теперь у картинки коллекции есть фон. проблема была в том, что свойство background-color переопределилось в вышестоящем компоненте (наследовалось), это мешало другим компонентам принять правильный фон через пропсы.

также промодифицировал стили компонента Button (ругался линтер) 