### PR TITLE
YH-871: add tests for Modal component

### DIFF
--- a/src/shared/ui/Modal/Modal.test.tsx
+++ b/src/shared/ui/Modal/Modal.test.tsx
@@ -1,0 +1,209 @@
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import {
+	closeIconColors,
+	modalTestIds,
+	outlineButtonVariants,
+	primaryButtonVariants,
+	titleColors,
+} from './constants';
+import { Modal } from './Modal';
+import type { ModalProps, ModalVariant, RequiredModalProps } from './ModalTypes';
+
+type OverrideProps = Partial<ModalProps>;
+
+const onClose = jest.fn();
+
+const render = (props: OverrideProps = {}) => {
+	const defaultProps: RequiredModalProps = {
+		isOpen: true,
+		onClose,
+	};
+	renderComponent(
+		<Modal {...defaultProps} {...props}>
+			Modal Content
+		</Modal>,
+	);
+};
+
+describe('Modal', () => {
+	describe('Rendering', () => {
+		test('renders modal with required props', () => {
+			render();
+
+			expect(screen.getByTestId(modalTestIds.modal)).toBeInTheDocument();
+			expect(screen.getByText('Modal Content')).toBeInTheDocument();
+			expect(screen.getByTestId(modalTestIds.modalCloseIcon)).toBeInTheDocument();
+			expect(screen.queryByTestId(modalTestIds.modalTitle)).not.toBeInTheDocument();
+			expect(screen.queryByTestId(modalTestIds.modalPrimaryButton)).not.toBeInTheDocument();
+			expect(screen.queryByTestId(modalTestIds.modalOutlineButton)).not.toBeInTheDocument();
+		});
+
+		test('renders with title', () => {
+			render({ title: 'Modal Title' });
+
+			expect(screen.getByTestId(modalTestIds.modalTitle)).toBeInTheDocument();
+			expect(screen.getByText('Modal Title')).toBeInTheDocument();
+		});
+
+		test('render with primary button', () => {
+			render({ buttonPrimaryText: 'Primary Text' });
+
+			expect(screen.getByTestId(modalTestIds.modalPrimaryButton)).toBeInTheDocument();
+			expect(screen.getByText('Primary Text')).toBeInTheDocument();
+		});
+
+		test('render with outline button', () => {
+			render({ buttonOutlineText: 'Outline Text' });
+
+			expect(screen.getByTestId(modalTestIds.modalOutlineButton)).toBeInTheDocument();
+			expect(screen.getByText('Outline Text')).toBeInTheDocument();
+		});
+
+		test('render with primary and outline buttons', () => {
+			render({
+				buttonPrimaryText: 'Primary Text',
+				buttonOutlineText: 'Outline Text',
+			});
+
+			expect(screen.getByTestId(modalTestIds.modalPrimaryButton)).toBeInTheDocument();
+			expect(screen.getByText('Primary Text')).toBeInTheDocument();
+			expect(screen.getByTestId(modalTestIds.modalOutlineButton)).toBeInTheDocument();
+			expect(screen.getByText('Outline Text')).toBeInTheDocument();
+		});
+
+		test('close icon button should not be rendered when withCloseIcon is false', () => {
+			render({ withCloseIcon: false });
+
+			expect(screen.queryByTestId(modalTestIds.modalCloseIcon)).not.toBeInTheDocument();
+		});
+
+		test('merges custom className with internal classes', () => {
+			render({ className: 'custom-class' });
+
+			expect(screen.getByTestId(modalTestIds.modalContentWrapper)).toHaveClass('custom-class');
+		});
+
+		test.each<ModalVariant>(['default', 'error'])('renders %s variant correctly', (variant) => {
+			render({
+				title: 'Modal Title',
+				variant: variant,
+				buttonPrimaryText: 'Primary Text',
+				buttonOutlineText: 'Outline Text',
+			});
+
+			expect(screen.getByTestId(modalTestIds.modal)).toHaveClass(`${variant}-modal`);
+
+			expect(screen.getByTestId(modalTestIds.modalTitle)).toHaveClass(
+				`text-${titleColors[variant]}`,
+			);
+			expect(screen.getByTestId(modalTestIds.modalCloseIcon)).toHaveStyle({
+				color: closeIconColors[variant],
+			});
+			expect(screen.getByTestId(modalTestIds.modalPrimaryButton)).toHaveClass(
+				`button-${primaryButtonVariants[variant]}`,
+			);
+			expect(screen.getByTestId(modalTestIds.modalOutlineButton)).toHaveClass(
+				`button-${outlineButtonVariants[variant]}`,
+			);
+		});
+
+		test('sets overflow to hidden when modal is open', () => {
+			render();
+
+			expect(document.body.style.overflow).toBe('hidden');
+			expect(screen.getByTestId(modalTestIds.modal)).toBeInTheDocument();
+		});
+
+		test('resets overflow when modal is closed', () => {
+			render({ isOpen: false });
+
+			expect(document.body.style.overflow).toBe('');
+			expect(screen.queryByTestId(modalTestIds.modal)).not.toBeInTheDocument();
+		});
+
+		test('resets overflow on unmount when modal is open', () => {
+			render();
+
+			expect(document.body.style.overflow).toBe('hidden');
+
+			cleanup();
+			expect(document.body.style.overflow).toBe('');
+		});
+	});
+
+	describe('Interactions', () => {
+		const onPrimaryClick = jest.fn();
+		const onOutlineClick = jest.fn();
+
+		test('calls buttonPrimaryClick when primary button is clicked', () => {
+			render({ buttonPrimaryText: 'Primary Text', buttonPrimaryClick: onPrimaryClick });
+
+			fireEvent.click(screen.getByTestId(modalTestIds.modalPrimaryButton));
+			expect(onPrimaryClick).toHaveBeenCalled();
+		});
+
+		test('calls buttonOutlineClick when outline button is clicked', () => {
+			render({ buttonOutlineText: 'Outline Text', buttonOutlineClick: onOutlineClick });
+
+			fireEvent.click(screen.getByTestId(modalTestIds.modalOutlineButton));
+			expect(onOutlineClick).toHaveBeenCalled();
+		});
+
+		test('primary button should be disabled when buttonPrimaryDisabled is true', () => {
+			render({
+				buttonPrimaryText: 'Primary Text',
+				buttonPrimaryDisabled: true,
+			});
+
+			expect(screen.getByTestId(modalTestIds.modalPrimaryButton)).toBeDisabled();
+		});
+
+		test('outline button should be disabled when buttonOutlineDisabled is true', () => {
+			render({
+				buttonOutlineText: 'Outline Text',
+				buttonOutlineDisabled: true,
+			});
+
+			expect(screen.getByTestId(modalTestIds.modalOutlineButton)).toBeDisabled();
+		});
+
+		test('calls onClose when close icon button is clicked', () => {
+			render();
+
+			fireEvent.click(screen.getByTestId(modalTestIds.modalCloseIcon));
+			expect(onClose).toHaveBeenCalled();
+		});
+
+		test('calls onClose when pressing Escape key', () => {
+			render();
+
+			fireEvent.keyDown(screen.getByTestId(modalTestIds.modalOverlay), { key: 'Escape' });
+			expect(onClose).toHaveBeenCalled();
+		});
+
+		test('does not call onClose when pressing non-Escape key', () => {
+			render();
+
+			fireEvent.keyDown(screen.getByTestId(modalTestIds.modalOverlay), { key: 'Enter' });
+			expect(onClose).not.toHaveBeenCalled();
+		});
+
+		test('calls onClose when clicking outside modal content (overlay)', () => {
+			render();
+
+			fireEvent.click(screen.getByTestId(modalTestIds.modalOverlay));
+			expect(onClose).toHaveBeenCalled();
+		});
+
+		test('does not call onClose when clicking inside modal content', () => {
+			render();
+
+			fireEvent.click(screen.getByTestId(modalTestIds.modal));
+			expect(onClose).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -2,41 +2,25 @@ import classNames from 'classnames';
 import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
-import { Pallete } from '@/shared/types/types';
 import { Button } from '@/shared/ui/Button';
 import { Icon } from '@/shared/ui/Icon';
-import { ModalProps } from '@/shared/ui/Modal/ModalTypes';
 import { Text } from '@/shared/ui/Text';
 
-import { VariantType } from '../Button/types';
-
+import {
+	closeIconColors,
+	modalTestIds,
+	outlineButtonVariants,
+	primaryButtonVariants,
+	titleColors,
+} from './constants';
 import styles from './Modal.module.css';
+import { ModalProps } from './ModalTypes';
 
 const createPortalRoot = () => {
 	const modalRoot = document.createElement('div');
 	modalRoot.setAttribute('id', 'modal-root');
 
 	return modalRoot;
-};
-
-const titleColors: Record<string, Pallete> = {
-	default: 'black-900',
-	error: 'red-700',
-};
-
-const closeIconColors: Record<string, Pallete> = {
-	default: 'purple-700',
-	error: 'red-600',
-};
-
-const primaryButtonVariants: Record<string, VariantType> = {
-	default: 'primary',
-	error: 'destructive',
-};
-
-const outlineButtonVariants: Record<string, VariantType> = {
-	default: 'outline',
-	error: 'destructive-outline',
 };
 
 export const Modal = ({
@@ -50,6 +34,7 @@ export const Modal = ({
 	buttonOutlineDisabled,
 	withCloseIcon = true,
 	variant = 'default',
+	dataTestId = 'Modal',
 	children,
 	title,
 	className = '',
@@ -107,10 +92,15 @@ export const Modal = ({
 			aria-labelledby="У вас открыто модальное окно"
 			tabIndex={0}
 			className={classNames(styles.overlay, { [styles['modal-open']]: isOpen })}
+			data-testid={modalTestIds.modalOverlay}
 			onKeyDown={handleKeyDown}
 			onClick={handleOverlayClick}
 		>
-			<div className={classNames(styles.modal, styles[`${variant}-modal`])} ref={overlayRef}>
+			<div
+				data-testid={dataTestId}
+				className={classNames(styles.modal, styles[`${variant}-modal`])}
+				ref={overlayRef}
+			>
 				{withCloseIcon && (
 					<Icon
 						icon="closeCircle"
@@ -120,15 +110,20 @@ export const Modal = ({
 						onClick={handleClickXCircle}
 						tabIndex={0}
 						aria-label="Закрыть модальное окно"
+						dataTestId={modalTestIds.modalCloseIcon}
 						onKeyDown={handleKeyDown}
 					/>
 				)}
-				<div className={classNames(styles['content-wrapper'], className)}>
+				<div
+					data-testid={modalTestIds.modalContentWrapper}
+					className={classNames(styles['content-wrapper'], className)}
+				>
 					{title && (
 						<Text
 							className={classNames(styles.title, styles[`${variant}-title`])}
 							variant="body5-accent"
 							color={titleColors[variant]}
+							dataTestId={modalTestIds.modalTitle}
 						>
 							{title}
 						</Text>
@@ -146,6 +141,7 @@ export const Modal = ({
 								size="large"
 								onClick={buttonPrimaryClick}
 								disabled={buttonPrimaryDisabled}
+								dataTestId={modalTestIds.modalPrimaryButton}
 								fullWidth
 							>
 								{buttonPrimaryText}
@@ -158,6 +154,7 @@ export const Modal = ({
 								size="large"
 								onClick={buttonOutlineClick}
 								disabled={buttonOutlineDisabled}
+								dataTestId={modalTestIds.modalOutlineButton}
 								fullWidth
 							>
 								{buttonOutlineText}

--- a/src/shared/ui/Modal/ModalTypes.ts
+++ b/src/shared/ui/Modal/ModalTypes.ts
@@ -1,3 +1,5 @@
+export type ModalVariant = 'default' | 'error';
+
 export type ModalProps = {
 	isOpen: boolean;
 	onClose: () => void;
@@ -9,7 +11,8 @@ export type ModalProps = {
 	buttonPrimaryDisabled?: boolean;
 	buttonOutlineDisabled?: boolean;
 	withCloseIcon?: boolean;
-	variant?: 'default' | 'error';
+	dataTestId?: string;
+	variant?: ModalVariant;
 	title?: string;
 	className?: string;
 };

--- a/src/shared/ui/Modal/constants.ts
+++ b/src/shared/ui/Modal/constants.ts
@@ -1,0 +1,34 @@
+import { Pallete } from '@/shared/types/types';
+import { VariantType } from '@/shared/ui/Button/types';
+
+import type { ModalVariant } from './ModalTypes';
+
+export const titleColors: Record<ModalVariant, Pallete> = {
+	default: 'black-900',
+	error: 'red-700',
+};
+
+export const closeIconColors: Record<ModalVariant, Pallete> = {
+	default: 'purple-700',
+	error: 'red-600',
+};
+
+export const primaryButtonVariants: Record<ModalVariant, VariantType> = {
+	default: 'primary',
+	error: 'destructive',
+};
+
+export const outlineButtonVariants: Record<ModalVariant, VariantType> = {
+	default: 'outline',
+	error: 'destructive-outline',
+};
+
+export const modalTestIds = {
+	modal: 'Modal',
+	modalOverlay: 'Modal_Overlay',
+	modalTitle: 'Modal_Title',
+	modalCloseIcon: 'Modal_Close_Icon',
+	modalContentWrapper: 'Modal_Content_Wrapper',
+	modalPrimaryButton: 'Modal_Primary_Button',
+	modalOutlineButton: 'Modal_Outline_Button',
+};


### PR DESCRIPTION
Добавлены тесты для компонента Modal

<img width="1000" height="44" alt="Screenshot 2025-08-17 234136" src="https://github.com/user-attachments/assets/cfad46c9-74c9-40b9-95a5-340939d2588e" />

не совсем 100%
не покрыта else-веткa, когда rootEl отсутствует

<img width="1284" height="221" alt="Screenshot 2025-08-17 233810" src="https://github.com/user-attachments/assets/2413a6f0-b016-426f-a712-2c281e54a7cf" />


