### PR TITLE
YH-1281: creating company, fixed submitting through refactoring schema and types

### DIFF
--- a/src/entities/company/model/types/companyTypes.ts
+++ b/src/entities/company/model/types/companyTypes.ts
@@ -19,7 +19,7 @@ export type GetCompanyByIdRequest = {
 	companyId: string;
 };
 
-export type CreateOrEditCompanyFormValues = Omit<Company, 'createdAt' | 'updatedAt'>;
+export type CreateOrEditCompanyFormValues = Omit<Company, 'createdAt' | 'updatedAt' | 'createdBy'>;
 
 export type GetCompaniesListResponse = Response<Company[]>;
 

--- a/src/entities/company/ui/CompanyForm/CompanyForm.tsx
+++ b/src/entities/company/ui/CompanyForm/CompanyForm.tsx
@@ -34,7 +34,7 @@ export const CompanyForm = ({ isEdit, imageSrc }: CompanyFormProps) => {
 
 	const removeImage = () => {
 		setPreviewImg(null);
-		setValue('imageSrc', null);
+		setValue('companyImage', null);
 	};
 
 	return (

--- a/src/features/company/createCompany/model/lib/validation/companyCreateSchema.ts
+++ b/src/features/company/createCompany/model/lib/validation/companyCreateSchema.ts
@@ -8,17 +8,11 @@ import { CreateCompanyFormValues } from '../../types/companyCreateTypes';
 export const companyCreateSchema: yup.ObjectSchema<CreateCompanyFormValues> = yup.object().shape({
 	id: yup.string(),
 	title: yup.string().required(i18n.t(Translation.VALIDATION_REQUIRED)),
-	legalName: yup.string(),
-	description: yup.string(),
-	imageSrc: yup.string().notRequired(),
-	companyImage: yup.string().notRequired(),
-	inn: yup.string(),
-	kpp: yup.string(),
-	createdBy: yup
-		.object()
-		.shape({
-			id: yup.string().required(),
-			username: yup.string().required(),
-		})
-		.optional(),
+	legalName: yup.string().optional(),
+	description: yup.string().optional(),
+	imageSrc: yup.string().nullable().optional(),
+	companyImage: yup.string().nullable().optional(),
+	inn: yup.string().optional(),
+	kpp: yup.string().optional(),
+	createdBy: yup.mixed().strip(true).optional(),
 });

--- a/src/features/company/createCompany/model/types/companyCreateTypes.ts
+++ b/src/features/company/createCompany/model/types/companyCreateTypes.ts
@@ -1,6 +1,8 @@
 import { CreateOrEditCompanyFormValues, Company } from '@/entities/company';
 
-export type CreateCompanyFormValues = Omit<CreateOrEditCompanyFormValues, 'id'>;
+export type CreateCompanyFormValues = Omit<CreateOrEditCompanyFormValues, 'id'> & {
+	companyImage?: string | null;
+};
 
 export type CreateCompanyBodyRequest = CreateCompanyFormValues;
 export type CreateCompanyResponse = Company;

--- a/src/features/company/createCompany/ui/CompanyCreateForm/CompanyCreateForm.tsx
+++ b/src/features/company/createCompany/ui/CompanyCreateForm/CompanyCreateForm.tsx
@@ -18,6 +18,9 @@ export const CompanyCreateForm = () => {
 	const companyMethods = useForm<CreateCompanyFormValues>({
 		resolver: yupResolver(companyCreateSchema),
 		mode: 'onTouched',
+		defaultValues: {
+			title: '',
+		},
 	});
 
 	const { isDirty, isSubmitting, isSubmitted } = companyMethods.formState;


### PR DESCRIPTION
Fixed the Create Company form submission: clicking SAVE now sends a POST /company.

Aligned the validation schema and default values with the backend contract (no extra empty strings).

Kept the form minimal — only title is required for now.