### PR TITLE
YH-945: add full unit test coverage for LandingLayout component

### DIFF
--- a/src/app/layouts/LandingLayout/model/helper/SkeletonGenerator.test.tsx
+++ b/src/app/layouts/LandingLayout/model/helper/SkeletonGenerator.test.tsx
@@ -1,0 +1,75 @@
+import { screen } from '@testing-library/react';
+import { useMatch } from 'react-router-dom';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { SkeletonGenerator } from './SkeletonGenerator';
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useMatch: jest.fn(),
+}));
+
+describe('SkeletonGenerator', () => {
+	const mockUseMatch = useMatch as jest.Mock;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render LandingPageSkeleton when isLandingPage is true', () => {
+		mockUseMatch.mockImplementation((route) => (route === '/' ? true : null));
+
+		renderComponent(<SkeletonGenerator />);
+
+		expect(screen.getByTestId('LandingPageSkeleton')).toBeInTheDocument();
+	});
+
+	test('should render CreatePublicQuizPageSkeleton when isQuizPage is true', () => {
+		mockUseMatch.mockImplementation((route) => (route === '/quiz' ? true : null));
+
+		renderComponent(<SkeletonGenerator />);
+
+		expect(screen.getByTestId('CreatePublicQuizPageSkeleton')).toBeInTheDocument();
+	});
+
+	test('should render PublicQuizPageSkeleton when isNewQuizPage is true', () => {
+		mockUseMatch.mockImplementation((route) => (route === '/quiz/new' ? true : null));
+
+		renderComponent(<SkeletonGenerator />);
+
+		expect(screen.getByTestId('PublicQuizPageSkeleton')).toBeInTheDocument();
+	});
+
+	test('should render PublicQuizResultPageSkeleton when isQuizResultPage is true', () => {
+		mockUseMatch.mockImplementation((route) => (route === '/quiz/result' ? true : null));
+
+		renderComponent(<SkeletonGenerator />);
+
+		expect(screen.getByTestId('PublicQuizResultPageSkeleton')).toBeInTheDocument();
+	});
+
+	test('should render PublicQuestionsPageSkeleton when isQuestionsPage is true', () => {
+		mockUseMatch.mockImplementation((route) => (route === '/questions' ? true : null));
+
+		renderComponent(<SkeletonGenerator />);
+
+		expect(screen.getByTestId('PublicQuestionsPageSkeleton')).toBeInTheDocument();
+	});
+
+	test('should render PublicQuestionPageSkeleton when isQuestionDetailPage is true', () => {
+		mockUseMatch.mockImplementation((route) => (route === '/questions/:questionId' ? true : null));
+
+		renderComponent(<SkeletonGenerator />);
+
+		expect(screen.getByTestId('PublicQuestionPageSkeleton')).toBeInTheDocument();
+	});
+
+	test('should render Loader when no match is found', () => {
+		mockUseMatch.mockReturnValue(null);
+
+		renderComponent(<SkeletonGenerator />);
+
+		expect(screen.getByText(/loading/i)).toBeInTheDocument();
+	});
+});

--- a/src/app/layouts/LandingLayout/model/helper/SkeletonGenerator.tsx
+++ b/src/app/layouts/LandingLayout/model/helper/SkeletonGenerator.tsx
@@ -4,27 +4,30 @@ import { ROUTES } from '@/shared/config/router/routes';
 import { Loader } from '@/shared/ui/Loader';
 
 import { CreatePublicQuizPageSkeleton } from '@/pages/landing/CreatePublicQuizPage';
-// import { LandingPageSkeleton } from '@/pages/landing/LandingPage';
+import { LandingPageSkeleton } from '@/pages/landing/LandingPage';
 import { PublicQuestionPageSkeleton } from '@/pages/landing/PublicQuestionPage';
 import { PublicQuestionsPageSkeleton } from '@/pages/landing/PublicQuestionsPage';
 import { PublicQuizPageSkeleton } from '@/pages/landing/PublicQuizPage';
 import { PublicQuizResultPageSkeleton } from '@/pages/landing/PublicQuizResultPage';
 
 export const SkeletonGenerator = () => {
-	// const isLandingPage = useMatch(ROUTES.appRoute);
+	const isLandingPage = useMatch(ROUTES.appRoute);
 	const isQuizPage = useMatch(ROUTES.quiz.page);
 	const isNewQuizPage = useMatch(ROUTES.quiz.new.page);
 	const isQuizResultPage = useMatch(ROUTES.quiz.result.page);
 	const isQuestionsPage = useMatch(ROUTES.questions.page);
 	const isQuestionDetailPage = useMatch(ROUTES.questions.detail.page);
 
-	// Расскомментировать после наличия полного скелетона для лендинга
-	// if (isLandingPage) return <LandingPageSkeleton />;
-	if (isQuizPage) return <CreatePublicQuizPageSkeleton />;
-	if (isNewQuizPage) return <PublicQuizPageSkeleton />;
-	if (isQuizResultPage) return <PublicQuizResultPageSkeleton />;
-	if (isQuestionsPage) return <PublicQuestionsPageSkeleton />;
-	if (isQuestionDetailPage) return <PublicQuestionPageSkeleton />;
+	if (isLandingPage) return <LandingPageSkeleton data-testid={'LandingPageSkeleton'} />;
+	if (isQuizPage)
+		return <CreatePublicQuizPageSkeleton data-testid={'CreatePublicQuizPageSkeleton'} />;
+	if (isNewQuizPage) return <PublicQuizPageSkeleton dataTestId={'PublicQuizPageSkeleton'} />;
+	if (isQuizResultPage)
+		return <PublicQuizResultPageSkeleton dataTestId={'PublicQuizResultPageSkeleton'} />;
+	if (isQuestionsPage)
+		return <PublicQuestionsPageSkeleton dataTestId={'PublicQuestionsPageSkeleton'} />;
+	if (isQuestionDetailPage)
+		return <PublicQuestionPageSkeleton dataTestId={'PublicQuestionPageSkeleton'} />;
 
 	return <Loader />;
 };

--- a/src/app/layouts/LandingLayout/ui/LandingLayout.skeleton.test.tsx
+++ b/src/app/layouts/LandingLayout/ui/LandingLayout.skeleton.test.tsx
@@ -1,0 +1,55 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { LandingLayoutSkeleton } from './LandingLayout.skeleton';
+
+describe('LandingLayoutSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		renderComponent(<LandingLayoutSkeleton />);
+	});
+
+	test('renders main Flex wrapper', () => {
+		const wrapper = screen.getByTestId('LandingLayoutSkeleton_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	test('renders HeaderSkeleton', () => {
+		const wrapper = screen.getByTestId('HeaderSkeleton_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	test('renders main element with correct class', () => {
+		const main = screen.getByTestId('LandingLayoutSkeleton_Main');
+		expect(main).toBeInTheDocument();
+		expect(main).toHaveClass('main');
+	});
+
+	test('renders main content Flex wrapper', () => {
+		const mainContent = screen.getByTestId('LandingLayoutSkeleton_MainContent');
+		expect(mainContent).toBeInTheDocument();
+		expect(mainContent).toHaveClass('main-content');
+	});
+
+	test('renders SkeletonGenerator inside main content', () => {
+		const mainContent = screen.getByTestId('LandingLayoutSkeleton_MainContent');
+		expect(mainContent).toBeInTheDocument();
+
+		expect(
+			mainContent.querySelector(
+				`[data-testid="LandingPageSkeleton"], 
+         [data-testid="CreatePublicQuizPageSkeleton"], 
+         [data-testid="PublicQuizPageSkeleton"], 
+         [data-testid="PublicQuizResultPageSkeleton"], 
+         [data-testid="PublicQuestionsPageSkeleton"], 
+         [data-testid="PublicQuestionPageSkeleton"]`,
+			),
+		).toBeInTheDocument();
+	});
+
+	test('renders FooterSkeleton', () => {
+		const footer = screen.getByTestId('FooterSkeleton');
+		expect(footer).toBeInTheDocument();
+	});
+});

--- a/src/app/layouts/LandingLayout/ui/LandingLayout.skeleton.tsx
+++ b/src/app/layouts/LandingLayout/ui/LandingLayout.skeleton.tsx
@@ -9,10 +9,14 @@ import styles from './LandingLayout.module.css';
 
 export const LandingLayoutSkeleton = () => {
 	return (
-		<Flex direction="column">
+		<Flex dataTestId={'LandingLayoutSkeleton_Wrapper'} direction="column">
 			<HeaderSkeleton />
-			<main className={styles.main}>
-				<Flex direction="column" className={styles['main-content']}>
+			<main data-testid={'LandingLayoutSkeleton_Main'} className={styles.main}>
+				<Flex
+					dataTestId={'LandingLayoutSkeleton_MainContent'}
+					direction="column"
+					className={styles['main-content']}
+				>
 					<SkeletonGenerator />
 				</Flex>
 			</main>

--- a/src/app/layouts/LandingLayout/ui/LandingLayout.test.tsx
+++ b/src/app/layouts/LandingLayout/ui/LandingLayout.test.tsx
@@ -1,0 +1,90 @@
+import { screen } from '@testing-library/react';
+import { Suspense } from 'react';
+import React from 'react';
+import { useMatch } from 'react-router-dom';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { SkeletonGenerator } from '../model/helper/SkeletonGenerator';
+
+import { LandingLayout } from './LandingLayout';
+import { LandingLayoutSkeleton } from './LandingLayout.skeleton';
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	Outlet: jest.fn(() => <div data-testid="Outlet">Mocked Outlet</div>),
+	useMatch: jest.fn(),
+}));
+
+describe('LandingLayout', () => {
+	const mockUseMatch = useMatch as jest.Mock;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockUseMatch.mockImplementation((route) => (route === '/' ? true : null));
+		renderComponent(<LandingLayout />);
+	});
+
+	test('renders main Flex wrapper', () => {
+		expect(screen.getByTestId('LandingLayout_Wrapper')).toBeInTheDocument();
+	});
+
+	test('renders Header', () => {
+		expect(screen.getByTestId('Header')).toBeInTheDocument();
+	});
+
+	test('renders AutoScrollToTop wrapper', () => {
+		expect(screen.getByTestId('AutoScrollToTop_Wrapper')).toBeInTheDocument();
+	});
+
+	test('renders main element with correct class', () => {
+		const main = screen.getByTestId('LandingLayout_Main');
+		expect(main).toBeInTheDocument();
+		expect(main).toHaveClass('main');
+	});
+
+	test('renders main content Flex wrapper', () => {
+		const mainContent = screen.getByTestId('LandingLayout_MainContent');
+		expect(mainContent).toBeInTheDocument();
+		expect(mainContent).toHaveClass('main-content');
+	});
+
+	test('renders Outlet inside main content', () => {
+		expect(screen.getByTestId('Outlet')).toBeInTheDocument();
+	});
+
+	test('renders Footer', () => {
+		expect(screen.getByTestId('Footer')).toBeInTheDocument();
+	});
+
+	test('renders CookiesWarning', () => {
+		expect(screen.getByTestId('CookiesWarning')).toBeInTheDocument();
+	});
+});
+
+describe('LandingLayout Suspense fallbacks', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const LazyComponent = React.lazy(() => new Promise(() => {}));
+
+	test('renders fallback LandingLayoutSkeleton in outer Suspense', async () => {
+		renderComponent(
+			<Suspense fallback={<LandingLayoutSkeleton />}>
+				<LazyComponent />
+			</Suspense>,
+		);
+
+		expect(screen.getByTestId('LandingLayoutSkeleton_Wrapper')).toBeInTheDocument();
+	});
+
+	test('renders fallback SkeletonGenerator in inner Suspense around Outlet', () => {
+		renderComponent(
+			<Suspense fallback={<SkeletonGenerator />}>
+				<LazyComponent />
+			</Suspense>,
+		);
+		expect(screen.getByTestId('LandingPageSkeleton')).toBeInTheDocument();
+	});
+});

--- a/src/app/layouts/LandingLayout/ui/LandingLayout.tsx
+++ b/src/app/layouts/LandingLayout/ui/LandingLayout.tsx
@@ -15,12 +15,16 @@ import { LandingLayoutSkeleton } from './LandingLayout.skeleton';
 
 export const LandingLayout = () => {
 	return (
-		<Flex direction="column">
+		<Flex dataTestId="LandingLayout_Wrapper" direction="column">
 			<Suspense fallback={<LandingLayoutSkeleton />}>
 				<Header />
 				<AutoScrollToTop>
-					<main className={styles.main}>
-						<Flex direction="column" className={styles['main-content']}>
+					<main data-testid="LandingLayout_Main" className={styles.main}>
+						<Flex
+							dataTestId="LandingLayout_MainContent"
+							direction="column"
+							className={styles['main-content']}
+						>
 							<Suspense fallback={<SkeletonGenerator />}>
 								<Outlet />
 							</Suspense>

--- a/src/pages/landing/CreatePublicQuizPage/ui/CreatePublicQuizPage.skeleton.tsx
+++ b/src/pages/landing/CreatePublicQuizPage/ui/CreatePublicQuizPage.skeleton.tsx
@@ -6,7 +6,7 @@ import styles from './CreatePublicQuizPage.module.css';
 
 export const CreatePublicQuizPageSkeleton = () => {
 	return (
-		<section>
+		<section data-testid={'CreatePublicQuizPageSkeleton'}>
 			<Card>
 				<Skeleton width={200} height={33} className={styles.title} />
 				<Flex className={styles.content} direction="row" justify="between" gap="40">

--- a/src/pages/landing/LandingPage/ui/LandingPage.skeleton.tsx
+++ b/src/pages/landing/LandingPage/ui/LandingPage.skeleton.tsx
@@ -6,12 +6,12 @@ import { SpecializationBlockSkeleton } from '@/widgets/Landing/SpecialityBlock';
 
 export const LandingPageSkeleton = () => {
 	return (
-		<>
+		<div data-testid={'LandingPageSkeleton'}>
 			<BannerBlockSkeleton />
 			<SpecializationBlockSkeleton />
 			<AboutQuestionsBlockSkeleton />
 			<InterviewTrainerBlockSkeleton />
 			<HistoryBlockSkeleton />
-		</>
+		</div>
 	);
 };

--- a/src/pages/landing/PublicQuestionPage/ui/PublicQuestionPage.skeleton.tsx
+++ b/src/pages/landing/PublicQuestionPage/ui/PublicQuestionPage.skeleton.tsx
@@ -8,11 +8,11 @@ import { QuestionHeaderSkeleton } from '@/widgets/question/QuestionHeader';
 
 import styles from './PublicQuestionPage.module.css';
 
-export const PublicQuestionPageSkeleton = () => {
+export const PublicQuestionPageSkeleton = ({ dataTestId }: { dataTestId?: string }) => {
 	const { isMobile, isTablet } = useScreenSize();
 
 	return (
-		<Flex direction="column" align="start">
+		<Flex dataTestId={dataTestId} direction="column" align="start">
 			<ButtonSkeleton
 				width={100}
 				size="small"

--- a/src/pages/landing/PublicQuestionsPage/ui/PublicQuestionsPage/PublicQuestionsPage.skeleton.tsx
+++ b/src/pages/landing/PublicQuestionsPage/ui/PublicQuestionsPage/PublicQuestionsPage.skeleton.tsx
@@ -8,9 +8,9 @@ import { PublicQuestionPagePaginationSkeleton } from '../PublicQuestionsPagePagi
 
 import styles from './PublicQuestionsPage.module.css';
 
-export const PublicQuestionsPageSkeleton = () => {
+export const PublicQuestionsPageSkeleton = ({ dataTestId }: { dataTestId?: string }) => {
 	return (
-		<Flex gap="20" align="start" className={styles.wrapper}>
+		<Flex dataTestId={dataTestId} gap="20" align="start" className={styles.wrapper}>
 			<Card className={styles.main}>
 				<FullQuestionsListSkeleton />
 				<PublicQuestionPagePaginationSkeleton />

--- a/src/pages/landing/PublicQuizPage/ui/PublicQuizPage.skeleton.tsx
+++ b/src/pages/landing/PublicQuizPage/ui/PublicQuizPage.skeleton.tsx
@@ -5,11 +5,11 @@ import { Skeleton } from '@/shared/ui/Skeleton/Skeleton';
 
 import styles from './PublicQuizPage.module.css';
 
-export const PublicQuizPageSkeleton = () => {
+export const PublicQuizPageSkeleton = ({ dataTestId }: { dataTestId?: string }) => {
 	const { isMobile } = useScreenSize();
 
 	return (
-		<Flex direction="column" className={styles.container}>
+		<Flex dataTestId={dataTestId} direction="column" className={styles.container}>
 			<Card>
 				<Flex gap="16" direction="column">
 					<div className={styles['progress-bar']}>

--- a/src/pages/landing/PublicQuizResultPage/ui/PublicQuizResultPage.skeleton.tsx
+++ b/src/pages/landing/PublicQuizResultPage/ui/PublicQuizResultPage.skeleton.tsx
@@ -7,11 +7,11 @@ import { PassedQuestionsStatisticSkeleton } from '@/widgets/interview/QuestionsS
 
 import styles from './PublicQuizResultPage.module.css';
 
-export const PublicQuizResultPageSkeleton = () => {
+export const PublicQuizResultPageSkeleton = ({ dataTestId }: { dataTestId?: string }) => {
 	const { isMobile, isTablet } = useScreenSize();
 
 	return (
-		<Flex gap="20" direction="column" className={styles.container}>
+		<Flex dataTestId={dataTestId} gap="20" direction="column" className={styles.container}>
 			<Flex gap="20" className={styles.wrapper} direction={isTablet || isMobile ? 'column' : 'row'}>
 				<PassedQuestionsStatisticSkeleton className={styles.statistic} total={0} />
 				<CategoryProgressListSkeleton className={styles.progress} />

--- a/src/shared/ui/AuthAvatarFrame/AuthAvatarFrame.test.tsx
+++ b/src/shared/ui/AuthAvatarFrame/AuthAvatarFrame.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { AuthAvatarFrame } from './AuthAvatarFrame';
+
+describe('AuthAvatarFrame', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render AvatarWithoutPhoto inside border wrapper when link is not provided', () => {
+		renderComponent(<AuthAvatarFrame link={null} />);
+
+		const wrapper = screen.getByTestId('AuthAvatarFrame_Border');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('border');
+
+		expect(screen.getByTestId('AvatarWithoutPhoto_Wrapper')).toBeInTheDocument();
+	});
+
+	test('should render user avatar image inside wrapper when link is provided', () => {
+		const testLink = 'https://example.com/avatar.png';
+		renderComponent(<AuthAvatarFrame link={testLink} />);
+
+		const wrapper = screen.getByTestId('AuthAvatarFrame_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('wrapper');
+
+		const img = screen.getByRole('img', { name: /User Avatar/i });
+		expect(img).toBeInTheDocument();
+		expect(img).toHaveAttribute('src', testLink);
+		expect(img).toHaveAttribute('alt', 'User Avatar');
+		expect(img).toHaveClass('avatar');
+	});
+});

--- a/src/shared/ui/AuthAvatarFrame/AuthAvatarFrame.tsx
+++ b/src/shared/ui/AuthAvatarFrame/AuthAvatarFrame.tsx
@@ -10,12 +10,12 @@ interface AvatarProps {
 export const AuthAvatarFrame = ({ link }: AvatarProps) => {
 	if (!link)
 		return (
-			<div className={styles.border}>
+			<div data-testid="AuthAvatarFrame_Border" className={styles.border}>
 				<AvatarWithoutPhoto />
 			</div>
 		);
 	return (
-		<div className={styles.wrapper}>
+		<div data-testid="AuthAvatarFrame_Wrapper" className={styles.wrapper}>
 			<img src={link} className={styles.avatar} alt="User Avatar" />
 		</div>
 	);

--- a/src/shared/ui/AutoScrollToTop/AutoScrollToTop.test.tsx
+++ b/src/shared/ui/AutoScrollToTop/AutoScrollToTop.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
+
+import { AutoScrollToTop } from './AutoScrollToTop';
+
+describe('AutoScrollToTop', () => {
+	beforeEach(() => {
+		Object.defineProperty(window, 'scrollTo', {
+			value: jest.fn(),
+			writable: true,
+		});
+		jest.clearAllMocks();
+	});
+
+	test('should render children without crashing', () => {
+		render(
+			<MemoryRouter initialEntries={['/']}>
+				<AutoScrollToTop>
+					<div>Test Content</div>
+				</AutoScrollToTop>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText('Test Content')).toBeInTheDocument();
+	});
+
+	test('should call window.scrollTo when route changes', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<MemoryRouter initialEntries={['/']}>
+				<Routes>
+					<Route
+						path="/"
+						element={
+							<AutoScrollToTop>
+								<div>
+									Home <Link to="/about">About Us</Link>
+								</div>
+							</AutoScrollToTop>
+						}
+					/>
+					<Route
+						path="/about"
+						element={
+							<AutoScrollToTop>
+								<div>About</div>
+							</AutoScrollToTop>
+						}
+					/>
+				</Routes>
+			</MemoryRouter>,
+		);
+
+		expect(window.scrollTo).toHaveBeenCalledTimes(1);
+
+		await user.click(screen.getByText('About Us'));
+
+		expect(window.scrollTo).toHaveBeenCalledTimes(2);
+		expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+	});
+});

--- a/src/shared/ui/AutoScrollToTop/AutoScrollToTop.tsx
+++ b/src/shared/ui/AutoScrollToTop/AutoScrollToTop.tsx
@@ -8,5 +8,5 @@ export const AutoScrollToTop = ({ children }: { children: React.ReactNode }) => 
 		window.scrollTo(0, 0);
 	}, [location.pathname]);
 
-	return <>{children}</>;
+	return <div data-testid="AutoScrollToTop_Wrapper">{children}</div>;
 };

--- a/src/shared/ui/AvatarWithoutPhoto/AvatarWithoutPhoto.test.tsx
+++ b/src/shared/ui/AvatarWithoutPhoto/AvatarWithoutPhoto.test.tsx
@@ -1,0 +1,26 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { AvatarWithoutPhoto } from './AvatarWithoutPhoto';
+
+describe('AvatarWithoutPhoto', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		renderComponent(<AvatarWithoutPhoto />);
+	});
+
+	test('should render wrapper with correct class', () => {
+		const wrapper = screen.getByTestId('AvatarWithoutPhoto_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('avatar-wrapper');
+	});
+
+	test('should render SVG icon with correct class and accessibility attributes', () => {
+		const icon = screen.getByRole('img', { name: /Аватар пользователя/i });
+		expect(icon).toBeInTheDocument();
+		expect(icon).toHaveClass('avatar-icon');
+		expect(icon).toHaveAttribute('focusable', 'false');
+		expect(icon).toHaveAttribute('aria-label', 'Аватар пользователя');
+	});
+});

--- a/src/shared/ui/AvatarWithoutPhoto/AvatarWithoutPhoto.tsx
+++ b/src/shared/ui/AvatarWithoutPhoto/AvatarWithoutPhoto.tsx
@@ -4,7 +4,7 @@ import styles from './AvatarWithoutPhoto.module.css';
 
 export const AvatarWithoutPhoto = () => {
 	return (
-		<div className={styles['avatar-wrapper']}>
+		<div data-testid="AvatarWithoutPhoto_Wrapper" className={styles['avatar-wrapper']}>
 			<WithoutPhotoIcon
 				role="img"
 				aria-label="Аватар пользователя"

--- a/src/shared/ui/Button/Button.skeleton.tsx
+++ b/src/shared/ui/Button/Button.skeleton.tsx
@@ -7,6 +7,7 @@ import { getTagName } from './helpers';
 import { ButtonProps } from './types';
 
 export const ButtonSkeleton = ({
+	dataTestId,
 	className,
 	variant = 'primary',
 	fullWidth,
@@ -18,6 +19,7 @@ export const ButtonSkeleton = ({
 
 	return (
 		<Skeleton
+			dataTestId={dataTestId}
 			borderRadius={12}
 			width={width}
 			className={classnames(

--- a/src/shared/ui/Icon/Icon.skeleton.tsx
+++ b/src/shared/ui/Icon/Icon.skeleton.tsx
@@ -2,6 +2,19 @@ import { Skeleton } from '@/shared/ui/Skeleton';
 
 import { IconProps } from './Icon';
 
-export const IconSkeleton = ({ size, className, borderRadius = 4 }: Partial<IconProps>) => {
-	return <Skeleton width={size} height={size} className={className} borderRadius={borderRadius} />;
+export const IconSkeleton = ({
+	dataTestId,
+	size,
+	className,
+	borderRadius = 4,
+}: Partial<IconProps>) => {
+	return (
+		<Skeleton
+			dataTestId={dataTestId}
+			width={size}
+			height={size}
+			className={className}
+			borderRadius={borderRadius}
+		/>
+	);
 };

--- a/src/shared/ui/IconButton/IconButton.skeleton.tsx
+++ b/src/shared/ui/IconButton/IconButton.skeleton.tsx
@@ -7,6 +7,7 @@ import styles from './IconButton.module.css';
 import { ButtonProps } from './';
 
 export const IconButtonSkeleton = ({
+	dataTestId,
 	variant = 'primary',
 	size = 'medium',
 	form = 'square',
@@ -16,6 +17,7 @@ export const IconButtonSkeleton = ({
 }: Omit<ButtonProps, 'icon'>) => {
 	return (
 		<Skeleton
+			dataTestId={dataTestId}
 			className={classnames(
 				styles['icon-button'],
 				styles[`icon-button-${form}`],

--- a/src/shared/ui/IconButton/IconButton.tsx
+++ b/src/shared/ui/IconButton/IconButton.tsx
@@ -8,6 +8,7 @@ import { ButtonProps } from './';
 export const IconButton = forwardRef<HTMLButtonElement, ButtonProps & { isActive?: boolean }>(
 	(
 		{
+			dataTestId,
 			variant = 'primary',
 			size = 'medium',
 			form = 'square',
@@ -22,6 +23,7 @@ export const IconButton = forwardRef<HTMLButtonElement, ButtonProps & { isActive
 	): JSX.Element => {
 		return (
 			<button
+				data-testid={dataTestId}
 				ref={ref}
 				className={classnames(
 					styles['icon-button'],

--- a/src/shared/ui/IconButton/types.ts
+++ b/src/shared/ui/IconButton/types.ts
@@ -10,6 +10,7 @@ export type VariantType =
 	| 'destructive-tertiary';
 
 export interface ButtonProps extends React.ComponentPropsWithRef<'button'> {
+	dataTestId?: string;
 	variant?: VariantType;
 	form?: 'square' | 'round';
 	size?: 'small' | 'medium' | 'large';

--- a/src/shared/ui/Loader/Loader.test.tsx
+++ b/src/shared/ui/Loader/Loader.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from '@testing-library/react';
+
+import { Translation } from '@/shared/config/i18n/i18nTranslations';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { Loader } from './Loader';
+
+describe('Loader', () => {
+	test('should render wrapper with default class', () => {
+		renderComponent(<Loader />);
+
+		const wrapper = screen.getByTestId('Loader_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('wrapper');
+	});
+
+	test('should render Card with loader content inside', () => {
+		renderComponent(<Loader />);
+
+		expect(screen.getByTestId('LoaderCard')).toBeInTheDocument();
+		expect(document.querySelector('.loader')).toBeInTheDocument();
+	});
+
+	test('should render loading text when hasText is true (default)', () => {
+		renderComponent(<Loader />);
+
+		expect(screen.getByTestId('Loader_Wrapper')).toHaveTextContent(Translation.LOADING);
+	});
+
+	test('should not render loading text when hasText is false', () => {
+		renderComponent(<Loader hasText={false} />);
+
+		expect(screen.getByTestId('Loader_Wrapper')).not.toHaveTextContent(Translation.LOADING);
+	});
+
+	test('should apply custom className and style', () => {
+		renderComponent(<Loader className="custom-class" style={{ color: 'red' }} />);
+
+		const wrapper = screen.getByTestId('Loader_Wrapper');
+		expect(wrapper).toHaveClass('wrapper');
+		expect(wrapper).toHaveClass('custom-class');
+		expect(wrapper).toHaveStyle({ color: 'red' });
+	});
+});

--- a/src/shared/ui/Loader/Loader.tsx
+++ b/src/shared/ui/Loader/Loader.tsx
@@ -18,8 +18,12 @@ export const Loader = ({ hasText = true, style, className }: LoaderProps) => {
 	const { t } = useTranslation(i18Namespace.translation);
 
 	return (
-		<div className={classNames(styles.wrapper, className)} style={style}>
-			<Card>
+		<div
+			data-testid={'Loader_Wrapper'}
+			className={classNames(styles.wrapper, className)}
+			style={style}
+		>
+			<Card dataTestId={'LoaderCard'}>
 				<div className={styles.content}>
 					<span className={styles.loader}></span>
 					{hasText && <span className={styles.text}>{t(Translation.LOADING)}</span>}

--- a/src/shared/ui/Popover/types.ts
+++ b/src/shared/ui/Popover/types.ts
@@ -26,6 +26,7 @@ export interface PopoverProps {
 }
 
 export interface PopoverMenuItem {
+	dataTestId?: string;
 	title?: string;
 	onClick?: () => void;
 	icon?: ReactNode;

--- a/src/shared/ui/Skeleton/Skeleton.tsx
+++ b/src/shared/ui/Skeleton/Skeleton.tsx
@@ -6,9 +6,11 @@ interface SkeletonBlockProps {
 	borderRadius?: string | number;
 	style?: React.CSSProperties;
 	className?: string;
+	dataTestId?: string;
 }
 
 export const Skeleton = ({
+	dataTestId,
 	width,
 	height,
 	borderRadius = '8px',
@@ -17,6 +19,7 @@ export const Skeleton = ({
 }: SkeletonBlockProps) => {
 	return (
 		<div
+			data-testid={dataTestId}
 			className={`${styles.skeleton} ${className}`}
 			style={{ width, height, borderRadius, ...style }}
 		/>

--- a/src/shared/ui/Text/Text.skeleton.tsx
+++ b/src/shared/ui/Text/Text.skeleton.tsx
@@ -4,6 +4,7 @@ import { TextProps } from './Text';
 import { TextVariant } from './types';
 
 export const TextSkeleton = ({
+	dataTestId,
 	className,
 	variant,
 	width,
@@ -32,6 +33,7 @@ export const TextSkeleton = ({
 
 	return (
 		<Skeleton
+			dataTestId={dataTestId}
 			className={className}
 			height={skeletonHeight[variant]}
 			width={width}

--- a/src/widgets/Landing/CookiesWarningBlock/ui/CookiesWarning.test.tsx
+++ b/src/widgets/Landing/CookiesWarningBlock/ui/CookiesWarning.test.tsx
@@ -1,0 +1,104 @@
+import { screen, fireEvent, waitFor, RenderResult } from '@testing-library/react';
+
+import { Landing } from '@/shared/config/i18n/i18nTranslations';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { CookiesWarning } from './CookiesWarning';
+
+jest.mock('@/shared/helpers/manageLocalStorage', () => ({
+	getJSONFromLS: jest.fn(() => null),
+	setToLS: jest.fn(),
+}));
+
+describe('CookiesWarning', () => {
+	let renderResult: RenderResult;
+
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		jest.clearAllMocks();
+
+		renderResult = renderComponent(<CookiesWarning />);
+	});
+
+	test('should render main wrapper and portal', () => {
+		const wrapper = screen.getByTestId('CookiesWarning');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('wrapper');
+		expect(screen.getByRole('alert')).toBe(wrapper);
+		expect(document.getElementById('cookie-root')).not.toBeNull();
+	});
+
+	test('should render inner container', () => {
+		const inner = document.querySelector('.cookie-wrapper');
+		expect(inner).toBeInTheDocument();
+	});
+
+	test('should render text and link with correct translations', () => {
+		const textBlock = document.querySelector('.text');
+		expect(textBlock).toBeInTheDocument();
+		expect(textBlock).toHaveTextContent(Landing.COOKIES_TEXT);
+
+		const linkText = document.querySelector('.link');
+		expect(linkText).toBeInTheDocument();
+		expect(linkText).toHaveTextContent(Landing.COOKIES_LINK);
+
+		const link = screen.getByRole('link', { name: Landing.COOKIES_LINK });
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute(
+			'href',
+			'https://docs.google.com/document/d/19JvySToaMm3pkohGkHwqhJjGl3IzldIc3qnQpAoVFVc/edit?tab=t.0#heading=h.gjdgxs',
+		);
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+	});
+
+	test('should render Agree button with correct classes and text', () => {
+		const button = screen.getByTestId('CookiesWarning_AgreeButton');
+		expect(button).toBeInTheDocument();
+		expect(button).toHaveClass('btn');
+		expect(button.className).toMatch(/button-primary/);
+		expect(button).toHaveTextContent(Landing.COOKIES_AGREE);
+	});
+
+	test('should save agreement to LS and remove banner and portal when Agree is clicked', async () => {
+		const { setToLS } = require('@/shared/helpers/manageLocalStorage');
+
+		fireEvent.click(screen.getByTestId('CookiesWarning_AgreeButton'));
+
+		expect(setToLS).toHaveBeenCalledWith('YH-cookie-modal', 'true');
+
+		await waitFor(() => {
+			expect(screen.queryByTestId('CookiesWarning')).toBeNull();
+			expect(document.getElementById('cookie-root')).toBeNull();
+		});
+	});
+
+	test('should not render banner if agreement already exists in LS', () => {
+		const { getJSONFromLS } = require('@/shared/helpers/manageLocalStorage');
+		getJSONFromLS.mockReturnValue(true);
+
+		renderResult.unmount();
+		renderResult = renderComponent(<CookiesWarning />);
+
+		expect(screen.queryByTestId('CookiesWarning')).toBeNull();
+		expect(document.getElementById('cookie-root')).toBeNull();
+	});
+
+	test('should remove portal on unmount', () => {
+		renderResult.unmount();
+
+		expect(document.getElementById('cookie-root')).toBeNull();
+	});
+
+	test('should render banner when LS flag is null', () => {
+		const { getJSONFromLS } = require('@/shared/helpers/manageLocalStorage');
+		getJSONFromLS.mockReturnValue(null);
+
+		renderResult.unmount();
+		renderResult = renderComponent(<CookiesWarning />);
+
+		const wrapper = screen.getByTestId('CookiesWarning');
+		expect(wrapper).toBeInTheDocument();
+		expect(document.getElementById('cookie-root')).not.toBeNull();
+	});
+});

--- a/src/widgets/Landing/CookiesWarningBlock/ui/CookiesWarning.tsx
+++ b/src/widgets/Landing/CookiesWarningBlock/ui/CookiesWarning.tsx
@@ -40,7 +40,7 @@ export const CookiesWarning = () => {
 	};
 
 	return createPortal(
-		<div role="alert" className={styles.wrapper}>
+		<div data-testid="CookiesWarning" role="alert" className={styles.wrapper}>
 			<div className={styles['cookie-wrapper']}>
 				<Text className={styles.text} variant="body3" color="black-700">
 					{t(Landing.COOKIES_TEXT)}{' '}
@@ -54,7 +54,12 @@ export const CookiesWarning = () => {
 						</Text>
 					</a>
 				</Text>
-				<Button className={styles.btn} variant="primary" onClick={handleClick}>
+				<Button
+					dataTestId="CookiesWarning_AgreeButton"
+					className={styles.btn}
+					variant="primary"
+					onClick={handleClick}
+				>
 					{t(Landing.COOKIES_AGREE)}
 				</Button>
 			</div>

--- a/src/widgets/Landing/Footer/ui/Footer.skeleton.test.tsx
+++ b/src/widgets/Landing/Footer/ui/Footer.skeleton.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { FooterSkeleton } from './Footer.skeleton';
+
+describe('FooterSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		renderComponent(<FooterSkeleton />);
+	});
+
+	test('should render FooterSkeleton wrapper with correct class', () => {
+		const wrapper = screen.getByTestId('FooterSkeleton');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('footer');
+	});
+
+	test('should render FooterSkeleton content wrapper with correct class', () => {
+		const contentWrapper = screen.getByTestId('FooterSkeleton_Content');
+		expect(contentWrapper).toBeInTheDocument();
+		expect(contentWrapper).toHaveClass('footer-content');
+	});
+
+	test('should render FooterMainSkeleton and FooterMetaSkeleton inside FooterSkeleton', () => {
+		expect(screen.getByTestId('FooterMainSkeleton')).toBeInTheDocument();
+		expect(screen.getByTestId('FooterMetaSkeleton')).toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Footer/ui/Footer.skeleton.tsx
+++ b/src/widgets/Landing/Footer/ui/Footer.skeleton.tsx
@@ -6,8 +6,8 @@ import { FooterMetaSkeleton } from './FooterMeta/FooterMeta.skeleton';
 
 export const FooterSkeleton = () => {
 	return (
-		<Flex className={styles.footer}>
-			<Flex className={styles['footer-content']}>
+		<Flex dataTestId={'FooterSkeleton'} className={styles.footer}>
+			<Flex dataTestId={'FooterSkeleton_Content'} className={styles['footer-content']}>
 				<FooterMainSkeleton />
 				<FooterMetaSkeleton />
 			</Flex>

--- a/src/widgets/Landing/Footer/ui/Footer.test.tsx
+++ b/src/widgets/Landing/Footer/ui/Footer.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { useProfileQuery } from '@/entities/auth';
+
+import { Footer } from './Footer';
+
+jest.mock('@/entities/auth', () => {
+	const actual = jest.requireActual('@/entities/auth');
+	return {
+		...actual,
+		useProfileQuery: jest.fn(),
+	};
+});
+
+describe('Footer', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render FooterSkeleton while profile is loading', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({ isLoading: true });
+
+		renderComponent(<Footer />);
+
+		expect(screen.getByTestId('FooterSkeleton')).toBeInTheDocument();
+	});
+
+	test('should render full Footer with FooterMain and FooterMeta after profile has loaded', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({ isLoading: false });
+
+		renderComponent(<Footer />);
+
+		const footer = screen.getByTestId('Footer');
+		expect(footer).toBeInTheDocument();
+		expect(footer).toHaveClass('footer');
+
+		const content = screen.getByTestId('Footer_Content');
+		expect(content).toBeInTheDocument();
+		expect(content).toHaveClass('footer-content');
+
+		expect(screen.getByTestId('FooterMain')).toBeInTheDocument();
+		expect(screen.getByTestId('FooterMeta')).toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Footer/ui/Footer.tsx
+++ b/src/widgets/Landing/Footer/ui/Footer.tsx
@@ -13,8 +13,8 @@ export const Footer = () => {
 	if (isLoading) return <FooterSkeleton />;
 
 	return (
-		<footer className={styles.footer}>
-			<Flex className={styles['footer-content']}>
+		<footer data-testid="Footer" className={styles.footer}>
+			<Flex dataTestId="Footer_Content" className={styles['footer-content']}>
 				<FooterMain />
 				<FooterMeta />
 			</Flex>

--- a/src/widgets/Landing/Footer/ui/FooterCopyright/FooterCopyright.skeleton.test.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterCopyright/FooterCopyright.skeleton.test.tsx
@@ -1,0 +1,47 @@
+import { screen } from '@testing-library/react';
+
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { FooterCopyrightSkeleton } from './FooterCopyright.skeleton';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({
+		isMobileS: false,
+	})),
+}));
+
+describe('FooterCopyrightSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render TextSkeleton', () => {
+		renderComponent(<FooterCopyrightSkeleton />);
+
+		const wrapper = screen.getByTestId('FooterCopyrightSkeleton');
+		expect(wrapper).toBeInTheDocument();
+	});
+
+	describe('TextSkeleton', () => {
+		test('should render TextSkeleton with default width and variant', () => {
+			renderComponent(<FooterCopyrightSkeleton />);
+
+			const textSkeleton = screen.getByTestId('FooterCopyrightSkeleton');
+			expect(textSkeleton).toBeInTheDocument();
+			expect(textSkeleton).toHaveStyle({ width: '100px' });
+			expect(textSkeleton).toHaveStyle({ height: '16.8px' });
+		});
+
+		test('should render TextSkeleton with correct styles on mobileS', () => {
+			(useScreenSize as jest.Mock).mockReturnValue({ isMobileS: true });
+
+			renderComponent(<FooterCopyrightSkeleton />);
+
+			const textSkeleton = screen.getByTestId('FooterCopyrightSkeleton');
+			expect(textSkeleton).toBeInTheDocument();
+			expect(textSkeleton).toHaveStyle({ width: '80px' });
+			expect(textSkeleton).toHaveStyle({ height: '16.8px' });
+		});
+	});
+});

--- a/src/widgets/Landing/Footer/ui/FooterCopyright/FooterCopyright.skeleton.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterCopyright/FooterCopyright.skeleton.tsx
@@ -4,5 +4,11 @@ import { TextSkeleton } from '@/shared/ui/Text';
 export const FooterCopyrightSkeleton = () => {
 	const { isMobileS } = useScreenSize();
 
-	return <TextSkeleton width={isMobileS ? 80 : 100} variant={'body2'} />;
+	return (
+		<TextSkeleton
+			dataTestId={'FooterCopyrightSkeleton'}
+			width={isMobileS ? 80 : 100}
+			variant={'body2'}
+		/>
+	);
 };

--- a/src/widgets/Landing/Footer/ui/FooterCopyright/FooterCopyright.test.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterCopyright/FooterCopyright.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from '@testing-library/react';
+
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { FooterCopyright } from './FooterCopyright';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({
+		isSmallScreen: false,
+	})),
+}));
+
+describe('FooterCopyright', () => {
+	const copyright = `© ${new Date().getFullYear()} YeaHub`;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render FooterCopyright with default variant and current year', () => {
+		renderComponent(<FooterCopyright />);
+
+		const element = screen.getByTestId('FooterCopyright');
+		expect(element).toBeInTheDocument();
+		expect(element).toHaveClass('body2-accent');
+		expect(element).toHaveStyle({ color: 'black-400' });
+		expect(element).toHaveTextContent(copyright);
+	});
+
+	test('should render FooterCopyright with body2 variant and current year on small screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isSmallScreen: true });
+
+		renderComponent(<FooterCopyright />);
+
+		const element = screen.getByTestId('FooterCopyright');
+		expect(element).toBeInTheDocument();
+		expect(element).toHaveClass('body2');
+		expect(element).toHaveStyle({ color: 'black-400' });
+		expect(element).toHaveTextContent(copyright);
+	});
+});

--- a/src/widgets/Landing/Footer/ui/FooterCopyright/FooterCopyright.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterCopyright/FooterCopyright.tsx
@@ -6,7 +6,11 @@ export const FooterCopyright = () => {
 	const currentYear = new Date().getFullYear();
 
 	return (
-		<Text variant={isSmallScreen ? 'body2' : 'body2-accent'} color="black-400">
+		<Text
+			dataTestId="FooterCopyright"
+			variant={isSmallScreen ? 'body2' : 'body2-accent'}
+			color="black-400"
+		>
 			© {currentYear} {'YeaHub'}
 		</Text>
 	);

--- a/src/widgets/Landing/Footer/ui/FooterLinks/FooterLinks.skeleton.test.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterLinks/FooterLinks.skeleton.test.tsx
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/react';
+
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { FooterLinksSkeleton } from './FooterLinks.skeleton';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({ isMobileS: false })),
+}));
+
+describe('FooterLinksSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		(useScreenSize as jest.Mock).mockReturnValue({ isMobileS: false });
+	});
+
+	test('should render Flex wrapper with correct class', () => {
+		renderComponent(<FooterLinksSkeleton />);
+
+		const wrapper = screen.getByTestId('FooterLinksSkeleton');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('footer-resources-links');
+	});
+
+	test('should render docs TextSkeleton with default width', () => {
+		renderComponent(<FooterLinksSkeleton />);
+
+		const textSkeleton = screen.getByTestId('TextSkeleton');
+		expect(textSkeleton).toBeInTheDocument();
+		expect(textSkeleton).toHaveClass('docs-link');
+		expect(textSkeleton).toHaveStyle({ width: '80px' });
+		expect(textSkeleton).toHaveStyle({ height: '16.8px' });
+	});
+
+	test('should render 5 IconSkeleton components with correct styles', () => {
+		renderComponent(<FooterLinksSkeleton />);
+
+		const icons = screen.getAllByTestId('IconSkeleton');
+		expect(icons).toHaveLength(5);
+
+		icons.forEach((icon) => {
+			expect(icon).toHaveStyle({ width: '24px' });
+			expect(icon).toHaveStyle({ height: '24px' });
+			expect(icon).toHaveStyle({ borderRadius: '50%' });
+		});
+	});
+
+	test('should adjust TextSkeleton width for mobile screens', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isMobileS: true });
+
+		renderComponent(<FooterLinksSkeleton />);
+
+		const textSkeleton = screen.getByTestId('TextSkeleton');
+		expect(textSkeleton).toHaveStyle({ width: '70px' });
+	});
+});

--- a/src/widgets/Landing/Footer/ui/FooterLinks/FooterLinks.skeleton.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterLinks/FooterLinks.skeleton.tsx
@@ -9,10 +9,15 @@ export const FooterLinksSkeleton = () => {
 	const { isMobileS } = useScreenSize();
 
 	return (
-		<Flex className={styles['footer-resources-links']}>
-			<TextSkeleton className={styles['docs-link']} width={isMobileS ? 70 : 80} variant={'body2'} />
+		<Flex dataTestId={'FooterLinksSkeleton'} className={styles['footer-resources-links']}>
+			<TextSkeleton
+				dataTestId={'TextSkeleton'}
+				className={styles['docs-link']}
+				width={isMobileS ? 70 : 80}
+				variant={'body2'}
+			/>
 			{[...Array(5)].map((_, index) => (
-				<IconSkeleton key={index} size={24} borderRadius={'50%'} />
+				<IconSkeleton dataTestId={'IconSkeleton'} key={index} size={24} borderRadius={'50%'} />
 			))}
 		</Flex>
 	);

--- a/src/widgets/Landing/Footer/ui/FooterLinks/FooterLinks.test.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterLinks/FooterLinks.test.tsx
@@ -1,0 +1,88 @@
+import { screen } from '@testing-library/react';
+
+import { Landing } from '@/shared/config/i18n/i18nTranslations';
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { RESOURCES_LINKS } from '../../model/constants/footerConstants';
+
+import { FooterLinks } from './FooterLinks';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({ isSmallScreen: false })),
+}));
+
+describe('FooterLinks', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should wrap all links inside Flex with correct class', () => {
+		renderComponent(<FooterLinks />);
+
+		const flexWrapper = screen.getByTestId('FooterLinks');
+		expect(flexWrapper).toBeInTheDocument();
+		expect(flexWrapper).toHaveClass('footer-resources-links');
+	});
+
+	test('should render docs and media links inside NavLink with correct href', () => {
+		renderComponent(<FooterLinks />);
+
+		const navDocs = screen.getByTestId('Footer_NavDocs');
+		expect(navDocs).toBeInTheDocument();
+		expect(navDocs).toHaveAttribute('href', '/docs');
+
+		const navMedia = screen.getByTestId('Footer_NavMedia');
+		expect(navMedia).toBeInTheDocument();
+		expect(navMedia).toHaveAttribute('href', '/media');
+	});
+
+	test('should render docs and media links with correct default variant, color, className and translation', () => {
+		renderComponent(<FooterLinks />);
+
+		const docsLink = screen.getByTestId('Footer_Docs');
+		expect(docsLink).toBeInTheDocument();
+		expect(docsLink).toHaveClass('body2-accent');
+		expect(docsLink).toHaveClass('docs-link');
+		expect(docsLink).toHaveStyle({ color: 'black-400' });
+		expect(docsLink).toHaveTextContent(Landing.FOOTER_DOCS);
+
+		const mediaLink = screen.getByTestId('Footer_Media');
+		expect(mediaLink).toBeInTheDocument();
+		expect(mediaLink).toHaveClass('body2-accent');
+		expect(mediaLink).toHaveClass('docs-link');
+		expect(mediaLink).toHaveStyle({ color: 'black-400' });
+		expect(mediaLink).toHaveTextContent(Landing.FOOTER_MEDIA);
+	});
+
+	test('should apply body2 variant on small screens', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isSmallScreen: true });
+
+		renderComponent(<FooterLinks />);
+
+		const docsLink = screen.getByTestId('Footer_Docs');
+		expect(docsLink).toHaveClass('body2');
+
+		const mediaLink = screen.getByTestId('Footer_Media');
+		expect(mediaLink).toHaveClass('body2');
+	});
+
+	test('should render all resource links with correct classes, translation and icon color', () => {
+		renderComponent(<FooterLinks />);
+
+		RESOURCES_LINKS.forEach(({ url, label, className, color }) => {
+			const link = screen.getByLabelText(`${label} ${Landing.FOOTER_LINKS_LINK_ARIA_LABEL}`);
+			expect(link).toBeInTheDocument();
+			expect(link).toHaveClass(className);
+			expect(link).toHaveAttribute('href', url);
+			expect(link).toHaveAttribute(
+				'aria-label',
+				`${label} ${Landing.FOOTER_LINKS_LINK_ARIA_LABEL}`,
+			);
+
+			const icon = screen.getByTestId(`icon-${label}`);
+			expect(icon).toBeInTheDocument();
+			expect(icon).toHaveAttribute('color', `var(--color-${color})`);
+		});
+	});
+});

--- a/src/widgets/Landing/Footer/ui/FooterLinks/FooterLinks.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterLinks/FooterLinks.tsx
@@ -17,9 +17,10 @@ export const FooterLinks = () => {
 	const { t } = useTranslation(i18Namespace.landing);
 
 	return (
-		<Flex className={styles['footer-resources-links']}>
-			<NavLink to={'/docs'}>
+		<Flex dataTestId={'FooterLinks'} className={styles['footer-resources-links']}>
+			<NavLink data-testid="Footer_NavDocs" to={'/docs'}>
 				<Text
+					dataTestId={'Footer_Docs'}
 					className={styles['docs-link']}
 					variant={isSmallScreen ? 'body2' : 'body2-accent'}
 					color="black-400"
@@ -27,8 +28,9 @@ export const FooterLinks = () => {
 					{t(Landing.FOOTER_DOCS)}
 				</Text>
 			</NavLink>
-			<NavLink to={'/media'}>
+			<NavLink data-testid="Footer_NavMedia" to={'/media'}>
 				<Text
+					dataTestId={'Footer_Media'}
 					className={styles['docs-link']}
 					variant={isSmallScreen ? 'body2' : 'body2-accent'}
 					color="black-400"
@@ -45,7 +47,7 @@ export const FooterLinks = () => {
 					aria-label={`${label} ${t(Landing.FOOTER_LINKS_LINK_ARIA_LABEL)}`}
 					className={styles[className]}
 				>
-					<Icon icon={icon} color={color} />
+					<Icon icon={icon} color={color} dataTestId={`icon-${label}`} />
 				</a>
 			))}
 		</Flex>

--- a/src/widgets/Landing/Footer/ui/FooterMain/FooterMain.skeleton.test.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterMain/FooterMain.skeleton.test.tsx
@@ -1,0 +1,79 @@
+import { screen } from '@testing-library/react';
+
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { FooterMainSkeleton } from './FooterMain.skeleton';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({
+		isMobile: false,
+		isMobileS: false,
+	})),
+}));
+
+describe('FooterMainSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render FooterMainSkeleton wrapper', () => {
+		renderComponent(<FooterMainSkeleton />);
+
+		const wrapper = screen.getByTestId('FooterMainSkeleton');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('footer-main');
+	});
+
+	describe('Logo skeleton', () => {
+		test('should render logo skeleton with correct class', () => {
+			renderComponent(<FooterMainSkeleton />);
+
+			const logo = screen.getByTestId('FooterMain_Logo');
+			expect(logo).toBeInTheDocument();
+			expect(logo).toHaveClass('footer-logo');
+		});
+	});
+
+	describe('Title skeleton', () => {
+		test('should render title skeleton with 30% width and correct class', () => {
+			renderComponent(<FooterMainSkeleton />);
+
+			const title = screen.getByTestId('FooterMain_Title');
+			expect(title).toBeInTheDocument();
+			expect(title).toHaveClass('footer-title');
+			expect(title).toHaveStyle({ width: '30%' });
+		});
+
+		test('should render title skeleton with 70% width on mobileS', () => {
+			(useScreenSize as jest.Mock).mockReturnValue({ isMobileS: true });
+
+			renderComponent(<FooterMainSkeleton />);
+
+			const title = screen.getByTestId('FooterMain_Title');
+			expect(title).toBeInTheDocument();
+			expect(title).toHaveStyle({ width: '70%' });
+		});
+
+		test('should render title skeleton with 50% width on mobile', () => {
+			(useScreenSize as jest.Mock).mockReturnValue({ isMobile: true });
+
+			renderComponent(<FooterMainSkeleton />);
+
+			const title = screen.getByTestId('FooterMain_Title');
+			expect(title).toBeInTheDocument();
+			expect(title).toHaveStyle({ width: '50%' });
+		});
+	});
+
+	describe('Description skeleton', () => {
+		test('should render description skeleton with default props', () => {
+			renderComponent(<FooterMainSkeleton />);
+
+			const description = screen.getByTestId('FooterMain_Description');
+			expect(description).toBeInTheDocument();
+			expect(description).toHaveClass('footer-description');
+			expect(description).toHaveStyle({ width: '96%' });
+		});
+	});
+});

--- a/src/widgets/Landing/Footer/ui/FooterMain/FooterMain.skeleton.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterMain/FooterMain.skeleton.tsx
@@ -9,14 +9,20 @@ export const FooterMainSkeleton = () => {
 	const { isMobile, isMobileS } = useScreenSize();
 
 	return (
-		<Flex className={styles['footer-main']}>
-			<IconSkeleton className={styles['footer-logo']} />
+		<Flex dataTestId="FooterMainSkeleton" className={styles['footer-main']}>
+			<IconSkeleton dataTestId="FooterMain_Logo" className={styles['footer-logo']} />
 			<TextSkeleton
+				dataTestId="FooterMain_Title"
 				className={styles['footer-title']}
 				width={isMobileS ? '70%' : isMobile ? '50%' : '30%'}
 				variant={isMobileS ? 'body2' : isMobile ? 'body3' : 'body3-accent'}
 			/>
-			<TextSkeleton className={styles['footer-description']} width="96%" variant="body1" />
+			<TextSkeleton
+				dataTestId="FooterMain_Description"
+				className={styles['footer-description']}
+				width="96%"
+				variant="body1"
+			/>
 		</Flex>
 	);
 };

--- a/src/widgets/Landing/Footer/ui/FooterMain/FooterMain.test.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterMain/FooterMain.test.tsx
@@ -1,0 +1,94 @@
+import { screen } from '@testing-library/react';
+
+import { Landing } from '@/shared/config/i18n/i18nTranslations';
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { FooterMain } from './FooterMain';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({
+		isMobile: false,
+		isMobileS: false,
+		isSmallScreen: false,
+	})),
+}));
+
+describe('FooterMain', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render FooterMain wrapper', () => {
+		renderComponent(<FooterMain />);
+
+		const component = screen.getByTestId('FooterMain');
+		expect(component).toBeInTheDocument();
+		expect(component).toHaveClass('footer-main');
+	});
+
+	describe('Logo', () => {
+		test('should render logo with correct aria-label translation', () => {
+			renderComponent(<FooterMain />);
+
+			const logo = screen.getByTestId('FooterMain_Logo');
+			expect(logo).toBeInTheDocument();
+			expect(logo).toHaveClass('footer-logo');
+			expect(logo).toHaveAttribute('aria-label', Landing.APP_LOGO_ARIA_LABEL);
+		});
+	});
+
+	describe('Title', () => {
+		test('should render title with default variant and translation', () => {
+			renderComponent(<FooterMain />);
+
+			const title = screen.getByTestId('FooterMain_Title');
+			expect(title).toBeInTheDocument();
+			expect(title).toHaveClass('footer-title');
+			expect(title).toHaveClass('body3-accent');
+			expect(title).toHaveTextContent(Landing.FOOTER_TITLE);
+		});
+
+		test('should apply body2 variant to title on mobileS', () => {
+			(useScreenSize as jest.Mock).mockReturnValue({ isMobileS: true });
+
+			renderComponent(<FooterMain />);
+
+			const title = screen.getByTestId('FooterMain_Title');
+			expect(title).toHaveClass('body2');
+			expect(title).toHaveTextContent(Landing.FOOTER_TITLE);
+		});
+
+		test('should apply body3 variant to title on mobile', () => {
+			(useScreenSize as jest.Mock).mockReturnValue({ isMobile: true });
+
+			renderComponent(<FooterMain />);
+
+			const title = screen.getByTestId('FooterMain_Title');
+			expect(title).toHaveClass('body3');
+			expect(title).toHaveTextContent(Landing.FOOTER_TITLE);
+		});
+	});
+
+	describe('Description', () => {
+		test('should render description with default variant and translation', () => {
+			renderComponent(<FooterMain />);
+
+			const description = screen.getByTestId('FooterMain_Description');
+			expect(description).toBeInTheDocument();
+			expect(description).toHaveClass('footer-description');
+			expect(description).toHaveClass('body1-accent');
+			expect(description).toHaveTextContent(Landing.FOOTER_DESCRIPTION);
+		});
+
+		test('should apply body1 variant to description on small screen', () => {
+			(useScreenSize as jest.Mock).mockReturnValue({ isSmallScreen: true });
+
+			renderComponent(<FooterMain />);
+
+			const description = screen.getByTestId('FooterMain_Description');
+			expect(description).toHaveClass('body1');
+			expect(description).toHaveTextContent(Landing.FOOTER_DESCRIPTION);
+		});
+	});
+});

--- a/src/widgets/Landing/Footer/ui/FooterMain/FooterMain.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterMain/FooterMain.tsx
@@ -14,14 +14,16 @@ export const FooterMain = () => {
 	const { isMobile, isMobileS, isSmallScreen } = useScreenSize();
 
 	return (
-		<Flex className={styles['footer-main']}>
+		<Flex dataTestId="FooterMain" className={styles['footer-main']}>
 			<Icon
+				dataTestId="FooterMain_Logo"
 				className={styles['footer-logo']}
 				icon={'logoText'}
 				aria-label={t(Landing.APP_LOGO_ARIA_LABEL)}
 				color="white-900"
 			/>
 			<Text
+				dataTestId="FooterMain_Title"
 				className={styles['footer-title']}
 				variant={isMobileS ? 'body2' : isMobile ? 'body3' : 'body3-accent'}
 				color="white-900"
@@ -29,6 +31,7 @@ export const FooterMain = () => {
 				{t(Landing.FOOTER_TITLE)}
 			</Text>
 			<Text
+				dataTestId="FooterMain_Description"
 				className={styles['footer-description']}
 				variant={isSmallScreen ? 'body1' : 'body1-accent'}
 				color="black-400"

--- a/src/widgets/Landing/Footer/ui/FooterMeta/FooterMeta.skeleton.test.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterMeta/FooterMeta.skeleton.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { FooterMetaSkeleton } from './FooterMeta.skeleton';
+
+describe('FooterMetaSkeleton', () => {
+	beforeEach(() => {
+		renderComponent(<FooterMetaSkeleton />);
+	});
+
+	test('renders Flex wrapper with FooterCopyrightSkeleton and FooterLinksSkeleton', () => {
+		const flexWrapper = screen.getByTestId('FooterMetaSkeleton');
+		expect(flexWrapper).toBeInTheDocument();
+		expect(flexWrapper).toHaveClass('justify-between');
+		expect(flexWrapper).toHaveClass('align-center');
+
+		expect(screen.getByTestId('FooterCopyrightSkeleton')).toBeInTheDocument();
+		expect(screen.getByTestId('FooterLinksSkeleton')).toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Footer/ui/FooterMeta/FooterMeta.skeleton.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterMeta/FooterMeta.skeleton.tsx
@@ -5,7 +5,7 @@ import { FooterLinksSkeleton } from '../FooterLinks/FooterLinks.skeleton';
 
 export const FooterMetaSkeleton = () => {
 	return (
-		<Flex justify="between" align="center">
+		<Flex dataTestId={'FooterMetaSkeleton'} justify="between" align="center">
 			<FooterCopyrightSkeleton />
 			<FooterLinksSkeleton />
 		</Flex>

--- a/src/widgets/Landing/Footer/ui/FooterMeta/FooterMeta.test.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterMeta/FooterMeta.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { FooterMeta } from './FooterMeta';
+
+describe('FooterMeta', () => {
+	beforeEach(() => {
+		renderComponent(<FooterMeta />);
+	});
+
+	test('should render Flex wrapper with FooterCopyright and FooterLinks components', () => {
+		const flexWrapper = screen.getByTestId('FooterMeta');
+		expect(flexWrapper).toBeInTheDocument();
+		expect(flexWrapper).toHaveClass('justify-between');
+		expect(flexWrapper).toHaveClass('align-center');
+
+		expect(screen.getByTestId('FooterCopyright')).toBeInTheDocument();
+		expect(screen.getByTestId('FooterLinks')).toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Footer/ui/FooterMeta/FooterMeta.tsx
+++ b/src/widgets/Landing/Footer/ui/FooterMeta/FooterMeta.tsx
@@ -5,7 +5,7 @@ import { FooterLinks } from '../FooterLinks/FooterLinks';
 
 export const FooterMeta = () => {
 	return (
-		<Flex justify="between" align="center">
+		<Flex dataTestId={'FooterMeta'} justify="between" align="center">
 			<FooterCopyright />
 			<FooterLinks />
 		</Flex>

--- a/src/widgets/Landing/Header/ui/AuthorizedBlock/AuthorizedBlock.test.tsx
+++ b/src/widgets/Landing/Header/ui/AuthorizedBlock/AuthorizedBlock.test.tsx
@@ -1,0 +1,71 @@
+import { screen, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+
+import { ROUTES } from '@/shared/config/router/routes';
+
+import { AuthorizedBlock } from './AuthorizedBlock';
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useNavigate: jest.fn(),
+}));
+
+describe('AuthorizedBlock', () => {
+	const mockNavigate = jest.fn();
+
+	const renderWithRouter = (ui: React.ReactNode) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+	const checkUsernameAndWrappers = (username: string) => {
+		const usernameEl = screen.getByTestId('UserName');
+		expect(usernameEl).toBeInTheDocument();
+		expect(usernameEl).toHaveClass('user-name');
+		expect(usernameEl).toHaveTextContent(username);
+
+		const userWrapper = screen.getByTestId('UserWrapper');
+		expect(userWrapper).toHaveClass('user-wrapper');
+
+		const mainWrapper = screen.getByTestId('AuthorizedBlock_Wrapper');
+		expect(mainWrapper).toHaveClass('wrapper');
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		(useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+	});
+
+	test('should render AuthAvatarFrame with avatar image when avatarURL is provided', () => {
+		const username = 'John Doe';
+		const avatarURL = 'https://example.com/avatar.png';
+		renderWithRouter(<AuthorizedBlock username={username} avatarURL={avatarURL} />);
+
+		checkUsernameAndWrappers(username);
+
+		const avatarFrame = screen.getByTestId('AuthAvatarFrame_Wrapper');
+		expect(avatarFrame).toBeInTheDocument();
+		expect(avatarFrame).toHaveClass('wrapper');
+	});
+
+	test('should render AvatarWithoutPhoto when avatarURL is not provided', () => {
+		const username = 'John Doe';
+		renderWithRouter(<AuthorizedBlock username={username} avatarURL={null} />);
+
+		checkUsernameAndWrappers(username);
+
+		const avatarFrame = screen.getByTestId('AuthAvatarFrame_Border');
+		expect(avatarFrame).toBeInTheDocument();
+		expect(avatarFrame).toHaveClass('border');
+
+		expect(screen.getByTestId('AvatarWithoutPhoto_Wrapper')).toBeInTheDocument();
+	});
+
+	test('should navigate to platform route when user wrapper is clicked', () => {
+		const username = 'John Doe';
+		renderWithRouter(<AuthorizedBlock username={username} avatarURL={null} />);
+
+		const userWrapper = screen.getByTestId('UserWrapper');
+		userWrapper.click();
+
+		expect(mockNavigate).toHaveBeenCalledWith(ROUTES.platformRoute);
+	});
+});

--- a/src/widgets/Landing/Header/ui/AuthorizedBlock/AuthorizedBlock.tsx
+++ b/src/widgets/Landing/Header/ui/AuthorizedBlock/AuthorizedBlock.tsx
@@ -20,9 +20,16 @@ export const AuthorizedBlock = ({ username, avatarURL }: UserProfileProps) => {
 	};
 
 	return (
-		<div className={styles.wrapper}>
-			<div role="banner" className={styles['user-wrapper']} onClick={handleClick}>
-				<p className={styles['user-name']}>{username}</p>
+		<div data-testid="AuthorizedBlock_Wrapper" className={styles.wrapper}>
+			<div
+				data-testid="UserWrapper"
+				role="banner"
+				className={styles['user-wrapper']}
+				onClick={handleClick}
+			>
+				<p data-testid="UserName" className={styles['user-name']}>
+					{username}
+				</p>
 				<AuthAvatarFrame link={avatarURL || null} />
 			</div>
 		</div>

--- a/src/widgets/Landing/Header/ui/Header/Header.skeleton.tsx
+++ b/src/widgets/Landing/Header/ui/Header/Header.skeleton.tsx
@@ -8,7 +8,7 @@ import styles from './Header.module.css';
 
 export const HeaderSkeleton = () => {
 	return (
-		<Flex className={styles.header}>
+		<Flex dataTestId={'HeaderSkeleton_Wrapper'} className={styles.header}>
 			<Flex className={styles['header-content']}>
 				<Flex className={styles['header-main']}>
 					<AppLogoSkeleton />

--- a/src/widgets/Landing/Header/ui/Header/Header.test.tsx
+++ b/src/widgets/Landing/Header/ui/Header/Header.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react';
+
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { useProfileQuery } from '@/entities/auth';
+
+import { Header } from './Header';
+
+jest.mock('@/entities/auth', () => {
+	const actual = jest.requireActual('@/entities/auth');
+	return {
+		...actual,
+		useProfileQuery: jest.fn(),
+	};
+});
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(),
+}));
+
+describe('Header', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render HeaderSkeleton while profile is loading', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({ isLoading: true });
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: true });
+
+		renderComponent(<Header />);
+
+		expect(screen.getByTestId('HeaderSkeleton_Wrapper')).toBeInTheDocument();
+		expect(screen.queryByTestId('Header')).not.toBeInTheDocument();
+	});
+
+	test('should render full Header after loading on large screen', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({ isLoading: false });
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: true });
+
+		renderComponent(<Header />);
+
+		expect(screen.getByTestId('Header')).toBeInTheDocument();
+		expect(screen.queryByTestId('HeaderSkeleton_Wrapper')).not.toBeInTheDocument();
+
+		expect(screen.getByTestId('AppLogo_Link')).toBeInTheDocument();
+
+		expect(screen.getByTestId('HeaderNavDesktop_Wrapper')).toBeInTheDocument();
+		expect(screen.queryByTestId('PopoverButton')).not.toBeInTheDocument();
+
+		expect(screen.getByTestId('HeaderAuthDesktop_Wrapper')).toBeInTheDocument();
+		expect(screen.queryByTestId('HeaderAuthMobile_IconButton')).not.toBeInTheDocument();
+	});
+
+	test('should render mobile Header with navigation and auth controls', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({ isLoading: false });
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: false });
+
+		renderComponent(<Header />);
+
+		expect(screen.queryByTestId('HeaderNavDesktop_Wrapper')).not.toBeInTheDocument();
+		expect(screen.getByTestId('PopoverButton')).toBeInTheDocument();
+
+		expect(screen.queryByTestId('HeaderAuthDesktop_Wrapper')).not.toBeInTheDocument();
+		expect(screen.getByTestId('HeaderAuthMobile_IconButton')).toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Header/ui/Header/Header.tsx
+++ b/src/widgets/Landing/Header/ui/Header/Header.tsx
@@ -16,7 +16,7 @@ export const Header = () => {
 	if (isLoading) return <HeaderSkeleton />;
 
 	return (
-		<header className={styles.header}>
+		<header data-testid={'Header'} className={styles.header}>
 			<Flex className={styles['header-content']}>
 				<Flex className={styles['header-main']}>
 					<AppLogo navigateTo={ROUTES.appRoute} />

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuth.skeleton.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuth.skeleton.test.tsx
@@ -1,0 +1,34 @@
+import { screen } from '@testing-library/react';
+
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderAuthSkeleton } from './HeaderAuth.skeleton';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({ isLargeScreen: true })),
+}));
+
+describe('HeaderAuthSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render HeaderAuthDesktopSkeleton on large screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: true });
+
+		renderComponent(<HeaderAuthSkeleton />);
+
+		expect(screen.getByTestId('HeaderAuthDesktopSkeleton_Wrapper')).toBeInTheDocument();
+		expect(screen.queryByTestId('HeaderAuthMobileSkeleton')).not.toBeInTheDocument();
+	});
+
+	test('should render HeaderAuthMobileSkeleton on small screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: false });
+
+		renderComponent(<HeaderAuthSkeleton />);
+
+		expect(screen.getByTestId('HeaderAuthMobileSkeleton')).toBeInTheDocument();
+		expect(screen.queryByTestId('HeaderAuthDesktopSkeleton_Wrapper')).not.toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuth.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuth.test.tsx
@@ -1,0 +1,34 @@
+import { screen } from '@testing-library/react';
+
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderAuth } from './HeaderAuth';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(),
+}));
+
+describe('HeaderAuth', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render HeaderAuthDesktop on large screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: true });
+
+		renderComponent(<HeaderAuth />);
+
+		expect(screen.getByTestId('HeaderAuthDesktop_Wrapper')).toBeInTheDocument();
+		expect(screen.queryByTestId('HeaderAuthMobile_IconButton')).not.toBeInTheDocument();
+	});
+
+	test('should render HeaderAuthMobile on small screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: false });
+
+		renderComponent(<HeaderAuth />);
+
+		expect(screen.getByTestId('HeaderAuthMobile_IconButton')).toBeInTheDocument();
+		expect(screen.queryByTestId('HeaderAuthDesktop_Wrapper')).not.toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthDesktop/HeaderAuthDesktop.skeketon.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthDesktop/HeaderAuthDesktop.skeketon.tsx
@@ -3,9 +3,14 @@ import { Flex } from '@/shared/ui/Flex';
 
 export const HeaderAuthDesktopSkeleton = () => {
 	return (
-		<Flex justify="between" align="center" gap="26">
-			<ButtonSkeleton size="small" width={40} />
-			<ButtonSkeleton size="large" width={171} />
+		<Flex
+			dataTestId={'HeaderAuthDesktopSkeleton_Wrapper'}
+			justify="between"
+			align="center"
+			gap="26"
+		>
+			<ButtonSkeleton dataTestId={'ButtonSkeleton'} size="small" width={40} />
+			<ButtonSkeleton dataTestId={'ButtonSkeleton'} size="large" width={171} />
 		</Flex>
 	);
 };

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthDesktop/HeaderAuthDesktop.skeleton.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthDesktop/HeaderAuthDesktop.skeleton.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderAuthDesktopSkeleton } from './HeaderAuthDesktop.skeketon';
+
+describe('HeaderAuthDesktopSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		renderComponent(<HeaderAuthDesktopSkeleton />);
+	});
+
+	test('should render Flex wrapper with correct classes', () => {
+		const flexWrapper = screen.getByTestId('HeaderAuthDesktopSkeleton_Wrapper');
+		expect(flexWrapper).toBeInTheDocument();
+		expect(flexWrapper).toHaveClass('justify-between');
+		expect(flexWrapper).toHaveClass('align-center');
+		expect(flexWrapper).toHaveClass('gap26');
+	});
+
+	test('should render two ButtonSkeleton components with correct classes and styles', () => {
+		const skeletons = screen.getAllByTestId('ButtonSkeleton');
+		expect(skeletons).toHaveLength(2);
+		expect(skeletons[0]).toHaveClass('button-small');
+		expect(skeletons[0]).toHaveStyle({ width: '40px' });
+		expect(skeletons[1]).toHaveClass('button-large');
+		expect(skeletons[1]).toHaveStyle({ width: '171px' });
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthDesktop/HeaderAuthDesktop.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthDesktop/HeaderAuthDesktop.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from '@testing-library/react';
+
+import { Landing } from '@/shared/config/i18n/i18nTranslations';
+import { ROUTES } from '@/shared/config/router/routes';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { useProfileQuery } from '@/entities/auth';
+
+import { HeaderAuthDesktop } from './HeaderAuthDesktop';
+
+jest.mock('@/entities/auth', () => {
+	const actual = jest.requireActual('@/entities/auth');
+	return {
+		...actual,
+		useProfileQuery: jest.fn(),
+	};
+});
+
+describe('HeaderAuthDesktop', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render AuthorizedBlock with username and avatar when user is logged in', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({
+			data: { username: 'John Doe', avatarUrl: 'https://example.com/avatar.png' },
+		});
+
+		renderComponent(<HeaderAuthDesktop />);
+
+		const wrapper = screen.getByTestId('AuthorizedBlock_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+
+		const usernameEl = screen.getByTestId('UserName');
+		expect(usernameEl).toHaveTextContent('John Doe');
+
+		const avatarFrame = screen.getByTestId('AuthAvatarFrame_Wrapper');
+		expect(avatarFrame).toBeInTheDocument();
+	});
+
+	test('should render login and register buttons when user is not logged in', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({ data: null });
+
+		renderComponent(<HeaderAuthDesktop />);
+
+		const loginLink = screen.getByRole('link', { name: Landing.LOGIN });
+		expect(loginLink).toHaveAttribute('href', ROUTES.auth.login.page);
+
+		const loginBtn = screen.getByTestId('LoginButton');
+		expect(loginBtn).toBeInTheDocument();
+		expect(loginBtn).toHaveClass('login-link');
+		expect(loginBtn).toHaveTextContent(Landing.LOGIN);
+
+		const registerLink = screen.getByRole('link', { name: Landing.REGISTER });
+		expect(registerLink).toHaveAttribute('href', ROUTES.auth.register.page);
+
+		const registerBtn = screen.getByTestId('RegisterButton');
+		expect(registerBtn).toBeInTheDocument();
+		expect(registerBtn).toHaveClass('register-button');
+		expect(registerBtn).toHaveTextContent(Landing.REGISTER);
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthDesktop/HeaderAuthDesktop.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthDesktop/HeaderAuthDesktop.tsx
@@ -21,15 +21,15 @@ export const HeaderAuthDesktop = () => {
 	return profile?.username ? (
 		<AuthorizedBlock username={profile.username} avatarURL={profile.avatarUrl} />
 	) : (
-		<Flex justify="between" align="center" gap="26">
+		<Flex dataTestId={'HeaderAuthDesktop_Wrapper'} justify="between" align="center" gap="26">
 			<Link to={ROUTES.auth.login.page}>
-				<Button variant="link" className={styles['login-link']}>
+				<Button dataTestId={'LoginButton'} variant="link" className={styles['login-link']}>
 					{t(Landing.LOGIN)}
 				</Button>
 			</Link>
 
-			<Link to={ROUTES.auth.register.page}>
-				<Button size="large" className={styles['register-button']}>
+			<Link dataTestId={'RegisterLink'} to={ROUTES.auth.register.page}>
+				<Button dataTestId={'RegisterButton'} size="large" className={styles['register-button']}>
 					{t(Landing.REGISTER)}
 				</Button>
 			</Link>

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthMobile/HeaderAuthMobile.skeleton.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthMobile/HeaderAuthMobile.skeleton.test.tsx
@@ -1,0 +1,19 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderAuthMobileSkeleton } from './HeaderAuthMobile.skeleton';
+
+describe('HeaderAuthMobileSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render IconButtonSkeleton with correct class for mobile skeleton', () => {
+		renderComponent(<HeaderAuthMobileSkeleton />);
+
+		const skeleton = screen.getByTestId('HeaderAuthMobileSkeleton');
+		expect(skeleton).toBeInTheDocument();
+		expect(skeleton).toHaveClass('burger-button-skeleton');
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthMobile/HeaderAuthMobile.skeleton.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthMobile/HeaderAuthMobile.skeleton.tsx
@@ -11,6 +11,7 @@ export const HeaderAuthMobileSkeleton = () => {
 
 	return (
 		<IconButtonSkeleton
+			dataTestId={'HeaderAuthMobileSkeleton'}
 			className={styles['burger-button-skeleton']}
 			aria-label={t(Landing.HEADER_AUTH_ICONBUTTON_ARIA_LABEL)}
 		/>

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthMobile/HeaderAuthMobile.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthMobile/HeaderAuthMobile.test.tsx
@@ -1,0 +1,79 @@
+import { screen, fireEvent } from '@testing-library/react';
+
+import { ROUTES } from '@/shared/config/router/routes';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { useProfileQuery } from '@/entities/auth';
+
+import { HeaderAuthMobile } from './HeaderAuthMobile';
+
+jest.mock('@/entities/auth', () => {
+	const actual = jest.requireActual('@/entities/auth');
+	return {
+		...actual,
+		useProfileQuery: jest.fn(),
+	};
+});
+
+export const navigateMock = jest.fn();
+
+jest.mock('react-router-dom', () => {
+	const actual = jest.requireActual('react-router-dom');
+	return {
+		...actual,
+		useNavigate: () => {
+			const { navigateMock } = require('./HeaderAuthMobile.test.tsx');
+			return navigateMock;
+		},
+	};
+});
+
+describe('HeaderAuthMobile', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render AuthorizedBlock when user is logged in with username and avatar', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({
+			data: { username: 'John Doe', avatarUrl: 'https://example.com/avatar.png' },
+		});
+
+		renderComponent(<HeaderAuthMobile />);
+
+		const wrapper = screen.getByTestId('AuthorizedBlock_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+
+		const usernameEl = screen.getByTestId('UserName');
+		expect(usernameEl).toHaveTextContent('John Doe');
+
+		const avatarFrame = screen.getByTestId('AuthAvatarFrame_Wrapper');
+		expect(avatarFrame).toBeInTheDocument();
+	});
+
+	test('should render popover with login and register buttons for unauthenticated user', () => {
+		(useProfileQuery as jest.Mock).mockReturnValue({ data: null });
+
+		renderComponent(<HeaderAuthMobile />);
+
+		const iconButton = screen.getByTestId('HeaderAuthMobile_IconButton');
+		expect(iconButton).toBeInTheDocument();
+
+		fireEvent.click(iconButton);
+
+		const popoverButtons = screen.getAllByTestId('Button');
+		expect(popoverButtons[0]).toBeInTheDocument();
+		expect(popoverButtons[1]).toBeInTheDocument();
+		expect(popoverButtons).toHaveLength(2);
+
+		fireEvent.click(popoverButtons[0]);
+		expect(navigateMock).toHaveBeenCalledWith(ROUTES.auth.login.page);
+
+		navigateMock.mockClear();
+
+		fireEvent.click(iconButton);
+
+		const newPopoverButtons = screen.getAllByTestId('Button');
+		fireEvent.click(newPopoverButtons[1]);
+		expect(navigateMock).toHaveBeenCalledWith(ROUTES.auth.register.page);
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthMobile/HeaderAuthMobile.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderAuth/HeaderAuthMobile/HeaderAuthMobile.tsx
@@ -45,6 +45,7 @@ export const HeaderAuthMobile = () => {
 		<Popover menuItems={authMenuLinks} className={styles['auth-popover']}>
 			{({ onToggle }) => (
 				<IconButton
+					dataTestId={'HeaderAuthMobile_IconButton'}
 					form="square"
 					variant="tertiary"
 					onClick={onToggle}

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNav.skeleton.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNav.skeleton.test.tsx
@@ -1,0 +1,34 @@
+import { screen } from '@testing-library/react';
+
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderNavSkeleton } from './HeaderNav.skeleton';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({ isLargeScreen: true })),
+}));
+
+describe('HeaderNavSkeleton', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render desktop skeleton on large screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: true });
+
+		renderComponent(<HeaderNavSkeleton />);
+
+		expect(screen.getByTestId('HeaderNavDesktopSkeleton_Wrapper')).toBeInTheDocument();
+		expect(screen.queryByTestId('HeaderNavMobileSkeleton_Wrapper')).not.toBeInTheDocument();
+	});
+
+	test('should render mobile skeleton on small screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: false });
+
+		renderComponent(<HeaderNavSkeleton />);
+
+		expect(screen.getByTestId('HeaderNavMobileSkeleton_Wrapper')).toBeInTheDocument();
+		expect(screen.queryByTestId('HeaderNavDesktopSkeleton_Wrapper')).not.toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNav.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNav.test.tsx
@@ -1,0 +1,43 @@
+import { screen } from '@testing-library/react';
+
+import { Landing } from '@/shared/config/i18n/i18nTranslations';
+import { useScreenSize } from '@/shared/hooks';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderNav } from './HeaderNav';
+
+jest.mock('@/shared/hooks', () => ({
+	useScreenSize: jest.fn(() => ({ isLargeScreen: true })),
+}));
+
+describe('HeaderNav', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('should render nav with correct aria-label', () => {
+		renderComponent(<HeaderNav />);
+
+		const navWrapper = screen.getByTestId('HeaderNav');
+		expect(navWrapper).toBeInTheDocument();
+		expect(navWrapper).toHaveAttribute('aria-label', Landing.HEADER_NAV_ARIA_LABEL);
+	});
+
+	test('should render desktop navigation on large screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: true });
+
+		renderComponent(<HeaderNav />);
+
+		expect(screen.getByTestId('HeaderNavDesktop_Wrapper')).toBeInTheDocument();
+		expect(screen.queryByTestId('PopoverButton')).not.toBeInTheDocument();
+	});
+
+	test('should render mobile navigation on small screen', () => {
+		(useScreenSize as jest.Mock).mockReturnValue({ isLargeScreen: false });
+
+		renderComponent(<HeaderNav />);
+
+		expect(screen.queryByTestId('HeaderNavDesktop_Wrapper')).not.toBeInTheDocument();
+		expect(screen.getByTestId('PopoverButton')).toBeInTheDocument();
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNav.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNav.tsx
@@ -12,7 +12,7 @@ export const HeaderNav = () => {
 	const { t } = useTranslation(i18Namespace.landing);
 
 	return (
-		<nav aria-label={t(Landing.HEADER_NAV_ARIA_LABEL)}>
+		<nav data-testid={'HeaderNav'} aria-label={t(Landing.HEADER_NAV_ARIA_LABEL)}>
 			{isLargeScreen ? <HeaderNavDesktop /> : <HeaderNavMobile />}
 		</nav>
 	);

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavDesktop.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavDesktop.test.tsx
@@ -1,0 +1,34 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HEADER_NAV_LINKS } from '@/widgets/Landing/Header/model/constants/headerConstants';
+
+import { HeaderNavDesktop } from './HeaderNavDesktop/HeaderNavDesktop';
+
+describe('HeaderNavDesktop', () => {
+	test('should render all nav links with correct text', () => {
+		renderComponent(<HeaderNavDesktop />);
+
+		HEADER_NAV_LINKS.forEach(({ title }) => {
+			const linkEl = screen.getByText(title);
+			expect(linkEl).toBeInTheDocument();
+		});
+	});
+
+	test('should render correct number of nav links', () => {
+		renderComponent(<HeaderNavDesktop />);
+
+		const links = screen.getAllByRole('link');
+		expect(links).toHaveLength(HEADER_NAV_LINKS.length);
+	});
+
+	test('should apply active class to the active link', () => {
+		const { link } = HEADER_NAV_LINKS[0];
+
+		renderComponent(<HeaderNavDesktop />, { route: `${link}` });
+
+		const activeLink = screen.getByRole('link', { name: HEADER_NAV_LINKS[0].title });
+		expect(activeLink).toHaveClass('active');
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavDesktop/HeaderNavDesktop.skeleton.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavDesktop/HeaderNavDesktop.skeleton.test.tsx
@@ -1,0 +1,28 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderNavDesktopSkeleton } from './HeaderNavDesktop.skeleton';
+
+describe('HeaderNavDesktopSkeleton', () => {
+	test('should render skeleton placeholders with correct styles', () => {
+		renderComponent(<HeaderNavDesktopSkeleton />);
+
+		const wrapper = screen.getByTestId('HeaderNavDesktopSkeleton_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('gap26');
+
+		const skeletons = screen.getAllByTestId('HeaderNavDesktopSkeleton');
+		expect(skeletons).toHaveLength(2);
+
+		expect(skeletons[0]).toBeInTheDocument();
+		expect(skeletons[0]).toHaveStyle({ width: '120px' });
+		expect(skeletons[0]).toHaveStyle({ height: '20px' });
+		expect(skeletons[0]).toHaveStyle({ borderRadius: '4px' });
+
+		expect(skeletons[1]).toBeInTheDocument();
+		expect(skeletons[1]).toHaveStyle({ width: '90px' });
+		expect(skeletons[1]).toHaveStyle({ height: '20px' });
+		expect(skeletons[1]).toHaveStyle({ borderRadius: '4px' });
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavDesktop/HeaderNavDesktop.skeleton.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavDesktop/HeaderNavDesktop.skeleton.tsx
@@ -3,9 +3,9 @@ import { Skeleton } from '@/shared/ui/Skeleton';
 
 export const HeaderNavDesktopSkeleton = () => {
 	return (
-		<Flex gap="26">
-			<Skeleton width={120} height={20} borderRadius={4} />
-			<Skeleton width={90} height={20} borderRadius={4} />
+		<Flex dataTestId={'HeaderNavDesktopSkeleton_Wrapper'} gap="26">
+			<Skeleton dataTestId={'HeaderNavDesktopSkeleton'} width={120} height={20} borderRadius={4} />
+			<Skeleton dataTestId={'HeaderNavDesktopSkeleton'} width={90} height={20} borderRadius={4} />
 		</Flex>
 	);
 };

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavDesktop/HeaderNavDesktop.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavDesktop/HeaderNavDesktop.tsx
@@ -10,7 +10,7 @@ export const HeaderNavDesktop = () => {
 	const { t } = useTranslation(i18Namespace.landing);
 
 	return (
-		<Flex gap="6">
+		<Flex dataTestId={'HeaderNavDesktop_Wrapper'} gap="6">
 			{HEADER_NAV_LINKS.map(({ link, path, title }) => (
 				<HeaderNavLink key={title} link={link} path={path}>
 					{t(title)}

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavMobile/HeaderNavMobile.skeleton.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavMobile/HeaderNavMobile.skeleton.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderNavMobileSkeleton } from './HeaderNavMobile.skeleton';
+
+describe('HeaderNavMobileSkeleton', () => {
+	beforeEach(() => {
+		renderComponent(<HeaderNavMobileSkeleton />);
+	});
+	test('should render wrapper with correct gap', () => {
+		const wrapper = screen.getByTestId('HeaderNavMobileSkeleton_Wrapper');
+		expect(wrapper).toBeInTheDocument();
+		expect(wrapper).toHaveClass('gap10');
+	});
+
+	test('should render two skeleton elements with correct sizes', () => {
+		const skeletons = screen.getAllByTestId('HeaderNavMobileSkeleton');
+		expect(skeletons).toHaveLength(2);
+		expect(skeletons[0]).toHaveStyle({ width: '93px', height: '20px', borderRadius: '4px' });
+		expect(skeletons[1]).toHaveStyle({ width: '20px', height: '20px', borderRadius: '4px' });
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavMobile/HeaderNavMobile.skeleton.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavMobile/HeaderNavMobile.skeleton.tsx
@@ -3,9 +3,9 @@ import { Skeleton } from '@/shared/ui/Skeleton';
 
 export const HeaderNavMobileSkeleton = () => {
 	return (
-		<Flex gap="10">
-			<Skeleton width={93} height={20} borderRadius={4} />
-			<Skeleton width={20} height={20} borderRadius={4} />
+		<Flex dataTestId={'HeaderNavMobileSkeleton_Wrapper'} gap="10">
+			<Skeleton dataTestId={'HeaderNavMobileSkeleton'} width={93} height={20} borderRadius={4} />
+			<Skeleton dataTestId={'HeaderNavMobileSkeleton'} width={20} height={20} borderRadius={4} />
 		</Flex>
 	);
 };

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavMobile/HeaderNavMobile.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavMobile/HeaderNavMobile.test.tsx
@@ -1,0 +1,63 @@
+import { screen, fireEvent } from '@testing-library/react';
+
+import { Landing } from '@/shared/config/i18n/i18nTranslations';
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HEADER_NAV_LINKS } from '@/widgets/Landing/Header/model/constants/headerConstants';
+
+import { HeaderNavMobile } from './HeaderNavMobile';
+
+describe('HeaderNavMobile', () => {
+	beforeEach(() => {
+		renderComponent(<HeaderNavMobile />);
+	});
+
+	test('should render popover button with correct class and text', () => {
+		const PopoverButton = screen.getByTestId('PopoverButton');
+		expect(PopoverButton).toBeInTheDocument();
+		expect(PopoverButton).toHaveClass('button');
+		expect(PopoverButton).toHaveTextContent(Landing.HEADER_NAV_POPOVER_TITLE);
+	});
+
+	test('should toggle aria-expanded on button click', () => {
+		const button = screen.getByTestId('PopoverButton');
+
+		expect(button).toHaveAttribute('aria-expanded', 'false');
+
+		fireEvent.click(button);
+		expect(button).toHaveAttribute('aria-expanded', 'true');
+	});
+
+	test('should render nav links inside popover when opened', () => {
+		const button = screen.getByTestId('PopoverButton');
+		fireEvent.click(button);
+
+		HEADER_NAV_LINKS.forEach(({ title }) => {
+			const linkEl = screen.getByText(title);
+			expect(linkEl).toBeInTheDocument();
+			expect(linkEl).toHaveTextContent(title);
+		});
+	});
+
+	test('should render correct number of nav links and close popover on second click', () => {
+		const button = screen.getByTestId('PopoverButton');
+
+		fireEvent.click(button);
+		expect(screen.getAllByRole('link')).toHaveLength(HEADER_NAV_LINKS.length);
+
+		fireEvent.click(button);
+		HEADER_NAV_LINKS.forEach(({ title }) => {
+			expect(screen.queryByText(title)).not.toBeInTheDocument();
+		});
+	});
+
+	test('should toggle arrow icon class when popover opens', () => {
+		const button = screen.getByTestId('PopoverButton');
+		const arrowIcon = screen.getByTestId('ArrowShortDown_Icon');
+
+		expect(arrowIcon).not.toHaveClass('arrow-open');
+
+		fireEvent.click(button);
+		expect(arrowIcon).toHaveClass('arrow-open');
+	});
+});

--- a/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavMobile/HeaderNavMobile.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNav/HeaderNavMobile/HeaderNavMobile.tsx
@@ -29,8 +29,10 @@ export const HeaderNavMobile = () => {
 		<Popover menuItems={popoverLinks} className={styles['header-popover']}>
 			{({ onToggle, isOpen }) => (
 				<Button
+					dataTestId={'PopoverButton'}
 					suffix={
 						<Icon
+							dataTestId={'ArrowShortDown_Icon'}
 							icon="arrowShortDown"
 							size={24}
 							className={`${styles.arrow} ${isOpen ? styles['arrow-open'] : ''}`}

--- a/src/widgets/Landing/Header/ui/HeaderNavLink/HeaderNavLink.test.tsx
+++ b/src/widgets/Landing/Header/ui/HeaderNavLink/HeaderNavLink.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from '@testing-library/react';
+
+import { renderComponent } from '@/shared/libs/jest/renderComponent/renderComponent';
+
+import { HeaderNavLink } from './HeaderNavLink';
+
+describe('HeaderNavLink', () => {
+	test('should render link with children text and active class when route matches', () => {
+		renderComponent(
+			<HeaderNavLink link="/test" path="">
+				Test Link
+			</HeaderNavLink>,
+			{ route: '/test' },
+		);
+
+		const linkEl = screen.getByRole('link', { name: 'Test Link' });
+		expect(linkEl).toBeInTheDocument();
+		expect(linkEl).toHaveClass('nav-link', 'link', 'active');
+	});
+
+	test('should apply active class when path matches current route', () => {
+		renderComponent(
+			<HeaderNavLink link="/other" path="/current">
+				Other Link
+			</HeaderNavLink>,
+			{ route: '/current' },
+		);
+
+		const linkEl = screen.getByRole('link', { name: 'Other Link' });
+		expect(linkEl).toBeInTheDocument();
+		expect(linkEl).toHaveClass('nav-link', 'link', 'active');
+	});
+
+	test('should not apply active class when link and path do not match current route', () => {
+		renderComponent(
+			<HeaderNavLink link="/other" path="/something">
+				Other Link
+			</HeaderNavLink>,
+			{ route: '/different' },
+		);
+
+		const linkEl = screen.getByRole('link', { name: 'Other Link' });
+		expect(linkEl).toBeInTheDocument();
+		expect(linkEl).toHaveClass('nav-link', 'link');
+	});
+
+	test('should render link correctly when path is not provided', () => {
+		renderComponent(
+			<HeaderNavLink link="/other" path="">
+				Other Link
+			</HeaderNavLink>,
+			{ route: '/different' },
+		);
+
+		const linkEl = screen.getByRole('link', { name: 'Other Link' });
+		expect(linkEl).toBeInTheDocument();
+		expect(linkEl).toHaveClass('nav-link', 'link');
+	});
+});


### PR DESCRIPTION
### **Что сделано**

### Добавлены unit-тесты для основных компонентов лендинга: 
-     LandingLayout
-     Header
-     Footer
-     CookiesWarning
-     AutoScrollToTop
-     Loader
-     SkeletonGenerator и др.

### Покрыты сценарии отображения в различных состояниях:
-     загрузка / скелетоны
-     десктопная и мобильная вёрстка
-     наличие и отсутствие данных (например, аватар, cookie agreement)
-     работа Suspense и корректный fallback
-     поведение при смене роутов (автоскролл, рендер нужных skeleton-компонентов)

### Добавлена проверка корректных атрибутов:
-     aria-label, role, className, href, target, rel, - что повышает доступность и надёжность UI.
![Uploading Set of tests.jpg…]()

