### PR TITLE
YH-1316: move paste plugin registration to onCreate

### DIFF
--- a/src/shared/ui/TextEditor/TextEditor.tsx
+++ b/src/shared/ui/TextEditor/TextEditor.tsx
@@ -116,6 +116,9 @@ export const TextEditor = ({
 			[onFocus],
 		),
 		onCreate({ editor }) {
+			const pastePlugin = createPastePlugin(editor);
+			editor.registerPlugin(pastePlugin);
+
 			editor.on('focus', () => {
 				const view = editor.view;
 				view.dom.style.outline = 'none';
@@ -168,12 +171,6 @@ export const TextEditor = ({
 		const node = editorContentRef.current;
 		node.addEventListener('keydown', handleTab);
 		return () => node.removeEventListener('keydown', handleTab);
-	}, [editor]);
-
-	useEffect(() => {
-		if (editor) {
-			editor.registerPlugin(createPastePlugin(editor));
-		}
 	}, [editor]);
 
 	return (

--- a/src/shared/ui/TextEditor/TextEditor.tsx
+++ b/src/shared/ui/TextEditor/TextEditor.tsx
@@ -116,8 +116,7 @@ export const TextEditor = ({
 			[onFocus],
 		),
 		onCreate({ editor }) {
-			const pastePlugin = createPastePlugin(editor);
-			editor.registerPlugin(pastePlugin);
+			editor.registerPlugin(createPastePlugin(editor));
 
 			editor.on('focus', () => {
 				const view = editor.view;


### PR DESCRIPTION
проблема возникала при первой отрисовке нескольких редакторов
перенесла регистрацию pastePlugin в onCreate, где плагин создаётся один раз для каждого экземпляра
теперь страница создания вопроса открывается без ошибок