### PR TITLE
YH-1313: fix quiz progress and navigation to unanswered question

### DIFF
--- a/src/entities/quiz/hooks/useSlideSwitcher.ts
+++ b/src/entities/quiz/hooks/useSlideSwitcher.ts
@@ -9,9 +9,8 @@ import { getHasPremiumAccess, getProfileId } from '@/entities/profile';
 
 import { changeMockQuestionAnswer, changeQuestionAnswer } from '../model/slices/activeQuizSlice';
 import { Answers, QuizQuestionAnswerType } from '../model/types/quiz';
-
-export const useSlideSwitcher = (questions: Answers[]) => {
-	const [currentQuestion, setCurrentQuestion] = useState(0);
+export const useSlideSwitcher = (questions: Answers[], initialSlideIndex?: number) => {
+	const [currentQuestion, setCurrentQuestion] = useState(initialSlideIndex || 0);
 
 	const dispatch = useAppDispatch();
 	const profileId = useAppSelector(getProfileId);

--- a/src/entities/quiz/model/selectors/quizSelectors.ts
+++ b/src/entities/quiz/model/selectors/quizSelectors.ts
@@ -12,8 +12,20 @@ export const getIsAllQuestionsAnswered = (state: State) => {
 
 export const getLastActiveQuizInfo = createSelector(
 	getActiveQuizQuestions,
-	(activeQuizQuestions) => {
+	getIsAllQuestionsAnswered,
+	(activeQuizQuestions, areAllQuestionsAnswered) => {
+		const answeredCount = activeQuizQuestions.filter(
+			(question) => question.answer !== undefined && question.answer !== null,
+		).length;
+
 		if (!activeQuizQuestions || !activeQuizQuestions.length) return null;
+		if (areAllQuestionsAnswered) {
+			return {
+				question: activeQuizQuestions[0],
+				fromQuestionNumber: activeQuizQuestions.length,
+				toQuestionNumber: activeQuizQuestions.length,
+			};
+		}
 
 		const questionWithoutAnswer =
 			activeQuizQuestions.find((question) => !question.answer) ?? activeQuizQuestions[0];
@@ -24,6 +36,7 @@ export const getLastActiveQuizInfo = createSelector(
 			question: questionWithoutAnswer,
 			fromQuestionNumber: questionIndexWithoutAnswer >= 0 ? questionIndexWithoutAnswer + 1 : 1,
 			toQuestionNumber: activeQuizQuestions.length,
+			answeredCount: answeredCount,
 		};
 	},
 );

--- a/src/pages/interview/InterviewQuizPage/ui/InterviewQuizPage.tsx
+++ b/src/pages/interview/InterviewQuizPage/ui/InterviewQuizPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -25,6 +25,7 @@ import {
 	useInterruptQuizMutation,
 	LS_ACTIVE_MOCK_QUIZ_KEY,
 	clearActiveMockQuizState,
+	getLastActiveQuizInfo,
 } from '@/entities/quiz';
 
 import { InterviewSlider } from '@/widgets/interview/InterviewSlider';
@@ -39,6 +40,13 @@ const InterviewQuizPage = () => {
 	const dispatch = useAppDispatch();
 
 	const { t } = useTranslation(i18Namespace.interviewQuiz);
+
+	const lastActiveQuizInfo = useAppSelector(getLastActiveQuizInfo);
+	const initialSlideIndex = useMemo(() => {
+		return lastActiveQuizInfo && lastActiveQuizInfo.question
+			? lastActiveQuizInfo.fromQuestionNumber - 1
+			: 0;
+	}, [lastActiveQuizInfo]);
 
 	const profileId = useAppSelector(getProfileId);
 	const { data: activeQuiz } = useGetActiveQuizQuery(
@@ -96,7 +104,7 @@ const InterviewQuizPage = () => {
 		changeAnswer,
 		goToNextSlide,
 		goToPrevSlide,
-	} = useSlideSwitcher(updatedQuiz ?? activeQuizQuestions ?? []);
+	} = useSlideSwitcher(updatedQuiz ?? activeQuizQuestions ?? [], initialSlideIndex);
 
 	const onPrevSlide = () => {
 		setIsAnswerVisible(false);

--- a/src/widgets/interview/InterviewPreparation/ui/PreviewActiveQuiz/PreviewActiveQuiz.tsx
+++ b/src/widgets/interview/InterviewPreparation/ui/PreviewActiveQuiz/PreviewActiveQuiz.tsx
@@ -16,7 +16,6 @@ export const PreviewActiveQuiz = () => {
 	const { t } = useTranslation(i18Namespace.interviewQuiz);
 
 	const lastActiveQuizInfo = useAppSelector(getLastActiveQuizInfo);
-
 	if (!lastActiveQuizInfo) {
 		return null;
 	}
@@ -24,7 +23,7 @@ export const PreviewActiveQuiz = () => {
 	return (
 		<Flex direction="column" gap="16" className={styles.preparation}>
 			<ProgressBar
-				currentCount={lastActiveQuizInfo.fromQuestionNumber}
+				currentCount={lastActiveQuizInfo.answeredCount ?? lastActiveQuizInfo.toQuestionNumber}
 				totalCount={lastActiveQuizInfo.toQuestionNumber}
 				label={t(InterviewQuiz.PROGRESS_BAR_TITLE, {
 					fromQuestionNumber: lastActiveQuizInfo.fromQuestionNumber,


### PR DESCRIPTION
Исправлен ход выполнения теста и навигация к неотвеченному вопросу.
Этот PR решает проблему, из-за которой тест всегда начинался с первого вопроса после
возврата со страницы InterviewQuizPage 
- Прогресс бар заполняется только после ответа на вопрос, на странице тренажера и на странице InterviewQuizPage (добавил answeredCount для подсчета)
- Теперь правильно определяет первый неотвеченный вопрос (добавил initialSlideIndex для перехода на вопрос)
- Если на все вопросы даны ответы, но пользователь не нажал проверить тест, при возвращении к тесту он переходит сразу к последнему вопросу

Задача: https://tracker.yandex.ru/YH-1313