### PR TITLE
YH-1386: Removed the specialization filter in ResourcesPage

### DIFF
--- a/src/pages/wiki/ResourcesPage/ui/ResourcesPage.tsx
+++ b/src/pages/wiki/ResourcesPage/ui/ResourcesPage.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import { i18Namespace } from '@/shared/config/i18n';
@@ -14,6 +16,7 @@ import { Icon } from '@/shared/ui/Icon';
 import { IconButton } from '@/shared/ui/IconButton';
 import { Text } from '@/shared/ui/Text';
 
+import { getSpecializationId } from '@/entities/profile';
 import { useGetResourcesListQuery } from '@/entities/resource';
 
 import {
@@ -32,6 +35,7 @@ const ResourcesPage = () => {
 	const { isOpen, onToggle, onClose } = useModal();
 	const { isMobile, isTablet } = useScreenSize();
 	const navigate = useNavigate();
+	const specializationID = useSelector(getSpecializationId);
 
 	const {
 		onChangeSearchParams,
@@ -51,10 +55,16 @@ const ResourcesPage = () => {
 		page: filter.page ?? 1,
 		limit: RESOURCES_PER_PAGE,
 		name: filter.title,
-		specializations: filter.specialization,
+		specializations: specializationID,
 		skills: filter.skills,
 		types: filter.resources,
 	});
+
+	useEffect(() => {
+		if (specializationID) {
+			onChangeSpecialization(specializationID);
+		}
+	}, []);
 
 	const resources = resourcesResponse?.data ?? [];
 
@@ -81,8 +91,8 @@ const ResourcesPage = () => {
 			}}
 			onChangeSearch={onChangeSearchParams}
 			onChangeSkills={onChangeSkills}
-			onChangeSpecialization={onChangeSpecialization}
 			onChangeResources={onChangeResources}
+			showSpecialization={false}
 		/>
 	);
 

--- a/src/widgets/Marketplace/ui/MarketplaceFiltersPanel/MarketplaceFiltersPanel.tsx
+++ b/src/widgets/Marketplace/ui/MarketplaceFiltersPanel/MarketplaceFiltersPanel.tsx
@@ -13,9 +13,10 @@ const DEFAULT_SPECIALIZATION = 11;
 interface MarketplaceFiltersPanelProps {
 	filter: FilterParams;
 	onChangeSearch: (value: string) => void;
-	onChangeSpecialization: (specialization: number[] | number) => void;
+	onChangeSpecialization?: (specialization: number[] | number) => void;
 	onChangeSkills: (skills: number[] | undefined) => void;
 	onChangeResources: (resources: string[] | undefined) => void;
+	showSpecialization?: boolean;
 }
 
 export const MarketplaceFiltersPanel = ({
@@ -24,6 +25,7 @@ export const MarketplaceFiltersPanel = ({
 	onChangeSpecialization,
 	onChangeSkills,
 	onChangeResources,
+	showSpecialization = true,
 }: MarketplaceFiltersPanelProps) => {
 	const { skills, specialization: filterSpecialization, resources } = filter;
 
@@ -37,20 +39,21 @@ export const MarketplaceFiltersPanel = ({
 
 	const handleSpecializationChange = (newSpecialization: number | undefined) => {
 		setLocalSpecialization(newSpecialization);
-		if (newSpecialization) {
+		if (newSpecialization && onChangeSpecialization) {
 			onChangeSpecialization([newSpecialization]);
 		}
 	};
-
 	// const keywords = ['JavaScript', 'React', 'Node.js', 'CSS', 'HTML'];
 
 	return (
 		<Flex direction="column" justify="start" gap="24">
 			<SearchBlock onChangeSearch={onChangeSearch} />
-			<SpecializationsListField
-				selectedSpecialization={localSpecialization}
-				onChangeSpecialization={handleSpecializationChange}
-			/>
+			{showSpecialization && (
+				<SpecializationsListField
+					selectedSpecialization={localSpecialization}
+					onChangeSpecialization={handleSpecializationChange}
+				/>
+			)}
 			<SkillsListField
 				selectedSkills={skills}
 				onChangeSkills={onChangeSkills}


### PR DESCRIPTION
1 В компоненте ResourcesPage  получаю id специализации, и с помощью useEffect подставляю его в onChangeSearchParams
2 В интерфейсе компонента MarketplaceFiltersPanel сделал onChangeSpecialization необязательным что-бы убрать его из компонента ResourcesPage, так-же чтоб TS не ругался сделал проверку if (newSpecialization && onChangeSpecialization) 
3 В самом компоненте MarketplaceFiltersPanel  сделал условие отображения блока SpecializationsListField