### PR TITLE
YH-1913: аdd company filter to admin collections

### DIFF
--- a/src/features/collections/filterCollections/ui/CollectionsFilters/CollectionsFilters.tsx
+++ b/src/features/collections/filterCollections/ui/CollectionsFilters/CollectionsFilters.tsx
@@ -86,6 +86,9 @@ export const CollectionsFilters = ({
 					onChangeSpecialization={handleSpecializationChange}
 				/>
 			)}
+			{project === 'admin' && onChangeCompany && (
+				<PublicCompanySelect value={company} onChange={onChangeCompany} />
+			)}
 			{onChangeKeyword && (
 				<KeywordSelect
 					value={keyword}

--- a/src/pages/admin/collection/collections/ui/CollectionsPage/CollectionsPage.tsx
+++ b/src/pages/admin/collection/collections/ui/CollectionsPage/CollectionsPage.tsx
@@ -46,6 +46,7 @@ const CollectionsPage = () => {
 		onChangePage,
 		onChangeIsFree,
 		onChangeSpecialization,
+		onChangeCompany,
 		onChangeIsMy,
 	} = useCollectionsFilters({
 		page: 1,
@@ -66,6 +67,7 @@ const CollectionsPage = () => {
 		page: filters.page,
 		titleOrDescriptionSearch: filters.title,
 		specializations: filters.specialization,
+		companies: filters.company,
 		isFree: filters.isFree,
 	});
 
@@ -128,6 +130,7 @@ const CollectionsPage = () => {
 							<CollectionsFilters
 								filter={filters}
 								onChangeSpecialization={onChangeSpecialization}
+								onChangeCompany={onChangeCompany}
 								onChangeIsFree={onChangeIsFree}
 								onChangeIsMy={onChangeIsMy}
 							/>


### PR DESCRIPTION

Добавил фильтрацию по компаниям на странице коллекций в админке.

Возник вопрос, какой компонент лучше использовать для выбора компании, так как существующие варианты отличаются.

CompanySelect использует подходящий для админки endpoint useGetCompaniesListQuery(...), но визуально и по поведению не очень подходит для этого фильтра: он крупнее, без заголовка, а выбранная компания отображается под селектом.

PublicCompanySelect лучше подходит по визуалу и UX для фильтра, но использует endpoint публичных компаний useGetPublicCompaniesListQuery(...), поэтому список компаний может отличаться от админского.

Сейчас нужно выбрать: либо использовать CompanySelect и доработать его отображение под фильтр, либо сделать отдельный admin-variant/select на базе PublicCompanySelect, но с запросом useGetCompaniesListQuery(...).

Сейчас по сути поставил PublicCompanySelect,  так как в таске [YH-1913] было указано сделать как в разделе admin/tasks.
