### PR TITLE
YH-1649: Repaint default close modal button from purple to white color

### DIFF
--- a/src/shared/ui/Modal/constants.ts
+++ b/src/shared/ui/Modal/constants.ts
@@ -9,7 +9,7 @@ export const titleColors: Record<ModalVariant, Pallete> = {
 };
 
 export const closeIconColors: Record<ModalVariant, Pallete> = {
-	default: 'purple-700',
+	default: 'white-900',
 	error: 'red-600',
 };
 


### PR DESCRIPTION
YH-1649 [bug] Незаметный крестик закрытия модалки
https://tracker.yandex.ru/YH-1649
+ изменил цвет крестика кнопки закрытия модалки с фиолетового на белый
<img width="627" height="659" alt="image" src="https://github.com/user-attachments/assets/0bc4aff8-05cf-4e55-b09f-97cd41141534" />
<img width="703" height="600" alt="image" src="https://github.com/user-attachments/assets/26b4d5fd-db40-4073-8b87-f4dde65597d5" />
