### PR TITLE
YH-1895: add mock for edit referral link request

### DIFF
--- a/src/app/msw/handlers.ts
+++ b/src/app/msw/handlers.ts
@@ -29,6 +29,7 @@ import { questionEditHandlers } from '@/features/question/editQuestion';
 import { learnQuestionHandlers } from '@/features/quiz/learnQuestion';
 import { resetQuestionHandlers } from '@/features/quiz/resetQuestionStudyProgress';
 import { referralLinkDeleteHandlers } from '@/features/referralLinks/deleteReferralLink';
+import { referralLinkEditHandlers } from '@/features/referralLinks/editReferralLink';
 import { skillCreateHandlers } from '@/features/skill/createSkill';
 import { skillDeleteHandlers } from '@/features/skill/deleteSkill';
 import { skillEditHandlers } from '@/features/skill/editSkill';
@@ -76,5 +77,6 @@ export const handlers = [
 	...programmingLanguageHandlers,
 	...referralLinksHandlers,
 	...referralLinkDeleteHandlers,
+	...referralLinkEditHandlers,
 	...taskHandlers,
 ];

--- a/src/entities/referralLink/api/__mocks__/index.ts
+++ b/src/entities/referralLink/api/__mocks__/index.ts
@@ -1,2 +1,2 @@
-import { referralLinksListMock } from './referralLinksListMock';
-export const referralLinksHandlers = [referralLinksListMock];
+import { referralLinksListMock, referralLinkByIdMock } from './referralLinksListMock';
+export const referralLinksHandlers = [referralLinksListMock, referralLinkByIdMock];

--- a/src/entities/referralLink/api/__mocks__/referralLinksListMock.ts
+++ b/src/entities/referralLink/api/__mocks__/referralLinksListMock.ts
@@ -26,3 +26,17 @@ export const referralLinksListMock = http.get<
 		limit: referralLinksMock.limit,
 	});
 });
+
+export const referralLinkByIdMock = http.get(
+	process.env.API_URL + referralLinksApiUrls.getReferralLinkById,
+	({ params }) => {
+		const { id } = params;
+		const link = referralLinksMock.data.find((link) => link.id === id);
+
+		if (!link) {
+			return HttpResponse.json({ message: 'Not found' }, { status: 404 });
+		}
+
+		return HttpResponse.json(link);
+	},
+);

--- a/src/features/referralLinks/editReferralLink/api/__mocks__/editReferralLinkMock.ts
+++ b/src/features/referralLinks/editReferralLink/api/__mocks__/editReferralLinkMock.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw';
+
+import { referralLinksMock } from '@/entities/referralLink';
+
+import type { EditReferralLinkBodyRequest } from '@/features/referralLinks/editReferralLink/model/types/referralEditPageTypes';
+
+import { editReferralLinkApiUrls } from '../../model/constants/editReferralLinkApiUrls';
+
+export const editReferralLinkMock = http.put(
+	`${process.env.API_URL}${editReferralLinkApiUrls.editReferralLink}`,
+	async ({ params, request }) => {
+		const { referralId } = params;
+		const body = (await request.json()) as EditReferralLinkBodyRequest;
+
+		const index = referralLinksMock.data.findIndex((link) => link.id === referralId);
+
+		if (index === -1) {
+			return HttpResponse.json({ message: 'Referral link not found' }, { status: 404 });
+		}
+
+		referralLinksMock.data[index] = {
+			...referralLinksMock.data[index],
+			...body,
+			updatedAt: new Date().toISOString(),
+		};
+
+		return HttpResponse.json(referralLinksMock.data[index], { status: 200 });
+	},
+);

--- a/src/features/referralLinks/editReferralLink/api/__mocks__/index.ts
+++ b/src/features/referralLinks/editReferralLink/api/__mocks__/index.ts
@@ -1,0 +1,4 @@
+import { editReferralLinkMock } from './editReferralLinkMock';
+
+export { editReferralLinkMock };
+export const referralLinkEditHandlers = [editReferralLinkMock];

--- a/src/features/referralLinks/editReferralLink/index.ts
+++ b/src/features/referralLinks/editReferralLink/index.ts
@@ -1,1 +1,2 @@
 export { ReferralLinkEditForm } from './ui/ReferralLinkEditForm/ReferralLinkEditForm';
+export { referralLinkEditHandlers } from './api/__mocks__/index';


### PR DESCRIPTION
YH-1895: Моки для запроса редактирования реферальной ссылки

Что было сделано:
- Добавлен мок-обработчик для PUT 'ref-links/:referralId' (редактирование реферальной ссылки)
- Добавлен мок-обработчик для GET 'ref-links/:id' (получение реферальной ссылки по ID) - необходим для загрузки данных на странице редактирования
- Обработчики подключены к глобальному списку обработчиков MSW
- Экспортирован 'referralLinkEditHandlers' из фичи 'editReferralLink'

https://tracker.yandex.ru/YH-1895