### PR TITLE
feature/YH-1935:  Added a feature flag details page

### DIFF
--- a/public/locales/en/featureFlags.json
+++ b/public/locales/en/featureFlags.json
@@ -1,0 +1,42 @@
+{
+	"stub": {
+		"empty": {
+			"featureFlags": {
+				"title": "No feature flags found yet",
+				"subtitle": "Create a feature flag or wait until someone creates one",
+				"submit": "Add"
+			}
+		},
+		"error": {
+			"featureFlags": {
+				"title": "Failed to load data",
+				"subtitle": "Please try again, this might solve the problem",
+				"submit": "Try again"
+			}
+		}
+	},
+	"table": {
+		"featureFlags": {
+			"flag": "Flag",
+			"description": "Description",
+			"enabled": "Enabled",
+			"roles": "Roles",
+			"clientType": "Client type",
+			"createdAt": "Created at",
+			"actions": "Actions"
+		}
+	},
+	"status": {
+		"featureFlags": {
+			"enabled": "Enabled",
+			"disabled": "Disabled"
+		}
+	},
+	"details": {
+		"roles": "Roles",
+		"clientType": "Client type",
+		"activity": "Activity",
+		"createdAt": "Created at",
+		"updatedAt": "Updated at"
+	}
+}

--- a/public/locales/ru/featureFlags.json
+++ b/public/locales/ru/featureFlags.json
@@ -1,0 +1,42 @@
+{
+	"stub": {
+		"empty": {
+			"featureFlags": {
+				"title": "Похоже здесь пока нет фича флагов",
+				"subtitle": "Создайте фича флаг или подождите, пока кто-то создаст его",
+				"submit": "Добавить"
+			}
+		},
+		"error": {
+			"featureFlags": {
+				"title": "Не удалось загрузить данные",
+				"subtitle": "Попробуйте еще раз, возможно это решит проблему",
+				"submit": "Повторить попытку"
+			}
+		}
+	},
+	"table": {
+		"featureFlags": {
+			"flag": "Флаг",
+			"description": "Описание",
+			"enabled": "Активность",
+			"roles": "Роли",
+			"clientType": "Тип клиента",
+			"createdAt": "Дата создания",
+			"actions": "Действия"
+		}
+	},
+	"status": {
+		"featureFlags": {
+			"enabled": "Включен",
+			"disabled": "Выключен"
+		}
+	},
+	"details": {
+		"roles": "Роли",
+		"clientType": "Тип клиента",
+		"activity": "Активность",
+		"createdAt": "Дата создания",
+		"updatedAt": "Дата изменения"
+	}
+}

--- a/src/app/providers/router/routeConfig.tsx
+++ b/src/app/providers/router/routeConfig.tsx
@@ -36,6 +36,7 @@ import { CompaniesTablePage } from '@/pages/admin/company/companies';
 import { CompanyCreatePage } from '@/pages/admin/company/companyCreate';
 import { CompanyDetailPage } from '@/pages/admin/company/companyDetail';
 import { CompanyEditPage } from '@/pages/admin/company/companyEdit';
+import { FeatureFlagsPage } from '@/pages/admin/featureFlag/featureFlags';
 import { MainPage as AdminMainPage } from '@/pages/admin/main';
 import { QuestionCreatePage } from '@/pages/admin/question/questionCreate';
 import { QuestionCreateMultiplePage } from '@/pages/admin/question/questionCreateMultiple';
@@ -301,6 +302,13 @@ const adminLayoutMenuItems: MenuItem[] = [
 		title: i18n.t(Translation.SIDEBAR_MENU_TASKS),
 		icon: TasksIcon,
 		roles: listAdminRoles,
+	},
+	{
+		type: 'single',
+		route: ROUTES.admin.featureFlags.route,
+		title: i18n.t(Translation.SIDEBAR_MENU_FEATURE_FLAGS),
+		icon: Crown,
+		roles: ['admin'],
 	},
 	{
 		type: 'single',
@@ -597,6 +605,16 @@ export const router = createBrowserRouter([
 					{
 						path: ROUTES.admin.tasks.details.route,
 						element: <AdminTaskPage />,
+					},
+				],
+			},
+			{
+				path: ROUTES.admin.featureFlags.route,
+				element: <Outlet />,
+				children: [
+					{
+						index: true,
+						element: <FeatureFlagsPage />,
 					},
 				],
 			},

--- a/src/app/providers/router/routeConfig.tsx
+++ b/src/app/providers/router/routeConfig.tsx
@@ -132,6 +132,7 @@ import { InterviewRoute } from './InterviewRoute';
 import { UnAuthRoute } from './UnAuthRoute';
 
 import '../../styles/App.css';
+import {FeatureFlagDetailsPage} from "@/pages/admin/featureFlag/featureFlagDetail";
 
 export const allRoles: RoleName[] = [
 	'guest',
@@ -616,6 +617,10 @@ export const router = createBrowserRouter([
 						index: true,
 						element: <FeatureFlagsPage />,
 					},
+					{
+						path: ROUTES.admin.featureFlags.details.route,
+						element: <FeatureFlagDetailsPage />
+					}
 				],
 			},
 			{

--- a/src/entities/featureFlag/api/featureFlagApi.ts
+++ b/src/entities/featureFlag/api/featureFlagApi.ts
@@ -1,0 +1,43 @@
+import { ApiTags, baseApi } from '@/shared/config';
+
+import { featureFlagApiUrls } from '../model/constants/featureFlags';
+import {
+	GetFeatureFlagsListParamsRequest,
+	GetFeatureFlagsListResponse,
+	FeatureFlagApiItem,
+} from '../model/types/featureFlag';
+
+export const featureFlagApi = baseApi.injectEndpoints({
+	endpoints: (build) => ({
+		getFeatureFlagsList: build.query<GetFeatureFlagsListResponse, GetFeatureFlagsListParamsRequest>(
+			{
+				query: (params) => ({
+					url: featureFlagApiUrls.getFeatureFlagsList,
+					params: { page: 1, limit: 10, clientType: 'WEB', ...params },
+				}),
+				providesTags: [ApiTags.FEATURE_FLAGS],
+			},
+		),
+		getFeatureFlagById: build.query<FeatureFlagApiItem, string>({
+			query: (id) => ({
+				url: `feature-flags/${id}`,
+				method: 'GET',
+			}),
+			providesTags: (result, error, id) => [{ type: ApiTags.FEATURE_FLAGS, id }],
+		}),
+		updateFeatureFlagStatus: build.mutation<FeatureFlagApiItem, { id: string; enabled: boolean }>({
+			query: ({ id, enabled }) => ({
+				url: `feature-flags/${id}`,
+				method: 'PATCH',
+				body: { enabled },
+			}),
+			invalidatesTags: (result, error, { id }) => [{ type: ApiTags.FEATURE_FLAGS, id }],
+		}),
+	}),
+});
+
+export const {
+	useGetFeatureFlagsListQuery,
+	useGetFeatureFlagByIdQuery,
+	useUpdateFeatureFlagStatusMutation,
+} = featureFlagApi;

--- a/src/entities/featureFlag/index.ts
+++ b/src/entities/featureFlag/index.ts
@@ -1,2 +1,12 @@
-export type { FeatureFlagType, FeatureFlag, FeatureFlags } from './model/types/featureFlag';
+export type {
+	FeatureFlagType,
+	FeatureFlag,
+	FeatureFlags,
+	FeatureFlagApiItem,
+	GetFeatureFlagsListParamsRequest,
+	GetFeatureFlagsListResponse,
+	ClientType,
+} from './model/types/featureFlag';
 export { WithFeature } from './ui/WithFeature/WithFeature';
+export { useGetFeatureFlagsListQuery, useGetFeatureFlagByIdQuery } from './api/featureFlagApi';
+export { featureFlagHandlers } from './api/__mocks__';

--- a/src/entities/featureFlag/index.ts
+++ b/src/entities/featureFlag/index.ts
@@ -8,5 +8,9 @@ export type {
 	ClientType,
 } from './model/types/featureFlag';
 export { WithFeature } from './ui/WithFeature/WithFeature';
-export { useGetFeatureFlagsListQuery, useGetFeatureFlagByIdQuery } from './api/featureFlagApi';
+export {
+	useGetFeatureFlagsListQuery,
+	useGetFeatureFlagByIdQuery,
+	useUpdateFeatureFlagStatusMutation,
+} from './api/featureFlagApi';
 export { featureFlagHandlers } from './api/__mocks__';

--- a/src/features/featureFlags/index.ts
+++ b/src/features/featureFlags/index.ts
@@ -1,0 +1,1 @@
+export { ToggleFeatureFlagStatus } from './toggleFeatureFlagStatus/ui/ToggleFeatureFlagStatus';

--- a/src/features/featureFlags/toggleFeatureFlagStatus/ui/ToggleFeatureFlagStatus.tsx
+++ b/src/features/featureFlags/toggleFeatureFlagStatus/ui/ToggleFeatureFlagStatus.tsx
@@ -1,0 +1,23 @@
+import { ChangeEvent } from 'react';
+
+import { Switch } from '@/shared/ui/Switch';
+
+import { useUpdateFeatureFlagStatusMutation } from '@/entities/featureFlag';
+
+interface ToggleFeatureFlagStatusProps {
+	featureFlagId: string;
+	enabled: boolean;
+}
+
+export const ToggleFeatureFlagStatus = ({
+	featureFlagId,
+	enabled,
+}: ToggleFeatureFlagStatusProps) => {
+	const [updateFeatureFlag, { isLoading }] = useUpdateFeatureFlagStatusMutation();
+
+	const handleToggle = (event: ChangeEvent<HTMLInputElement>) => {
+		updateFeatureFlag({ id: featureFlagId, enabled: event.target.checked });
+	};
+
+	return <Switch checked={enabled} onChange={handleToggle} disabled={isLoading} />;
+};

--- a/src/pages/admin/featureFlag/featureFlagDetail/index.ts
+++ b/src/pages/admin/featureFlag/featureFlagDetail/index.ts
@@ -1,0 +1,1 @@
+export { FeatureFlagDetailsPage } from './ui/FeatureFlagDetailsPage/FeatureFlagDetailsPage.lazy';

--- a/src/pages/admin/featureFlag/featureFlagDetail/ui/FeatureFlagDetailsPage/FeatureFlagDetailsPage.lazy.ts
+++ b/src/pages/admin/featureFlag/featureFlagDetail/ui/FeatureFlagDetailsPage/FeatureFlagDetailsPage.lazy.ts
@@ -1,0 +1,3 @@
+import { lazy } from 'react';
+
+export const FeatureFlagDetailsPage = lazy(() => import('./FeatureFlagDetailsPage'));

--- a/src/pages/admin/featureFlag/featureFlagDetail/ui/FeatureFlagDetailsPage/FeatureFlagDetailsPage.tsx
+++ b/src/pages/admin/featureFlag/featureFlagDetail/ui/FeatureFlagDetailsPage/FeatureFlagDetailsPage.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+
+import { FeatureFlags, i18Namespace } from '@/shared/config';
+
+import { useGetFeatureFlagByIdQuery } from '@/entities/featureFlag';
+
+import { PageWrapper } from '@/widgets/PageWrapper';
+
+import { FeatureFlagDetailsPageContent } from '../FeatureFlagDetailsPageContent/FeatureFlagDetailsPageContent';
+
+const FeatureFlagDetailsPage = () => {
+	const { flagId } = useParams<{ flagId: string }>();
+	const { t } = useTranslation([i18Namespace.featureFlags]);
+
+	if (!flagId) {
+		return null;
+	}
+
+	const { data, isLoading, isError, refetch } = useGetFeatureFlagByIdQuery(flagId);
+	const content = data && <FeatureFlagDetailsPageContent featureFlag={data} />;
+
+	const stubs = {
+		error: {
+			title: t(FeatureFlags.STUB_ERROR_TITLE),
+			text: t(FeatureFlags.STUB_ERROR_TEXT),
+			buttonText: t(FeatureFlags.STUB_ERROR_BUTTON),
+			onClick: refetch,
+		},
+	};
+
+	return (
+		<PageWrapper
+			roles={['admin']}
+			isLoading={isLoading}
+			hasError={isError}
+			hasData={!!data}
+			stubs={stubs}
+			content={content}
+		>
+			{({ content }) => content}
+		</PageWrapper>
+	);
+};
+
+export default FeatureFlagDetailsPage;

--- a/src/pages/admin/featureFlag/featureFlagDetail/ui/FeatureFlagDetailsPageContent/FeatureFlagDetailsPageContent.module.css
+++ b/src/pages/admin/featureFlag/featureFlagDetail/ui/FeatureFlagDetailsPageContent/FeatureFlagDetailsPageContent.module.css
@@ -1,0 +1,7 @@
+.mainCard {
+  width: 100%
+}
+
+.additionalCard {
+  min-width: 360px;
+}

--- a/src/pages/admin/featureFlag/featureFlagDetail/ui/FeatureFlagDetailsPageContent/FeatureFlagDetailsPageContent.tsx
+++ b/src/pages/admin/featureFlag/featureFlagDetail/ui/FeatureFlagDetailsPageContent/FeatureFlagDetailsPageContent.tsx
@@ -1,0 +1,87 @@
+import { useTranslation } from 'react-i18next';
+
+import { FeatureFlags, i18Namespace } from '@/shared/config';
+import { BackHeader } from '@/shared/ui/BackHeader';
+import { Card } from '@/shared/ui/Card';
+import { Chip } from '@/shared/ui/Chip';
+import { Flex } from '@/shared/ui/Flex';
+import { Text } from '@/shared/ui/Text';
+
+import { FeatureFlagApiItem } from '@/entities/featureFlag';
+import { UserRolesList } from '@/entities/user';
+
+import { ToggleFeatureFlagStatus } from '@/features/featureFlags';
+
+import styles from './FeatureFlagDetailsPageContent.module.css';
+
+interface FeatureFlagDetailsPageContentProps {
+	featureFlag: FeatureFlagApiItem;
+}
+
+export const FeatureFlagDetailsPageContent = ({
+	featureFlag,
+}: FeatureFlagDetailsPageContentProps) => {
+	const { t } = useTranslation([i18Namespace.featureFlags]);
+	return (
+		<>
+			<BackHeader></BackHeader>
+
+			<Flex gap="20" align="start" justify="between">
+				<Card withOutsideShadow className={styles.mainCard}>
+					<Flex direction="column" gap="20" maxWidth>
+						<Text variant="head2">{featureFlag.flag}</Text>
+						<Text variant="body1">{featureFlag.description}</Text>
+					</Flex>
+				</Card>
+
+				<Card withOutsideShadow className={styles.additionalCard}>
+					<Flex direction="column" gap="16">
+						<Flex align="start" direction="column" gap="16">
+							<Text variant="body1" color="black-700">
+								{t(FeatureFlags.DETAILS_ROLES)}
+							</Text>
+							<UserRolesList userRoles={featureFlag.roles ?? []} />
+						</Flex>
+
+						<Flex align="start" direction="column" gap="16">
+							<Text variant="body1" color="black-700">
+								{t(FeatureFlags.DETAILS_CLIENT_TYPE)}
+							</Text>
+							<Chip label={featureFlag.clientType}></Chip>
+						</Flex>
+
+						<Flex align="start" direction="column" gap="16">
+							<Text variant="body1" color="black-700">
+								{t(FeatureFlags.DETAILS_ACTIVITY)}
+							</Text>
+							<ToggleFeatureFlagStatus
+								featureFlagId={featureFlag.id}
+								enabled={featureFlag.enabled}
+							/>
+						</Flex>
+
+						<Flex align="start" direction="column" gap="16">
+							<Text variant="body1" color="black-700">
+								{t(FeatureFlags.DETAILS_CREATED_AT)}
+							</Text>
+							<Chip
+								theme="outlined"
+								label={new Date(featureFlag.createdAt).toLocaleDateString()}
+							></Chip>
+						</Flex>
+
+						<Flex align="start" direction="column" gap="16">
+							<Text variant="body1" color="black-700">
+								{t(FeatureFlags.DETAILS_UPDATED_AT)}
+							</Text>
+							<Chip
+								theme="outlined"
+								label={new Date(featureFlag.updatedAt).toLocaleDateString()}
+							></Chip>
+						</Flex>
+					</Flex>
+				</Card>
+			</Flex>
+		</>
+	);
+};

--- a/src/pages/admin/featureFlag/featureFlags/ui/FeatureFlagPage/FeatureFlagsTablePage.tsx
+++ b/src/pages/admin/featureFlag/featureFlags/ui/FeatureFlagPage/FeatureFlagsTablePage.tsx
@@ -1,0 +1,153 @@
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { FeatureFlags, i18Namespace, ROUTES } from '@/shared/config';
+import { route } from '@/shared/libs';
+import { SelectedEntities } from '@/shared/libs';
+import { Flex } from '@/shared/ui/Flex';
+import { Icon } from '@/shared/ui/Icon';
+import { IconButton } from '@/shared/ui/IconButton';
+import { Popover, PopoverMenuItem } from '@/shared/ui/Popover';
+import { StatusChip, StatusChipItem } from '@/shared/ui/StatusChip';
+import { Table } from '@/shared/ui/Table';
+import { Text } from '@/shared/ui/Text';
+
+import { FeatureFlagApiItem } from '@/entities/featureFlag';
+import { UserRolesList } from '@/entities/user';
+
+interface FeatureFlagsTableProps {
+	featureFlags?: FeatureFlagApiItem[];
+	selectedItems?: SelectedEntities<string>;
+	onSelectItems?: (ids: SelectedEntities<string>) => void;
+}
+
+export const FeatureFlagsTable = ({
+	featureFlags,
+	selectedItems,
+	onSelectItems,
+}: FeatureFlagsTableProps) => {
+	const { t } = useTranslation([i18Namespace.featureFlags]);
+
+	const renderTableColumnWidths = () => {
+		const columnWidths = {
+			flag: 'auto',
+			description: 'auto',
+			enabled: '15%',
+			roles: '15%',
+			clientType: '15%',
+			createdAt: '15%',
+			actions: '10%',
+		};
+
+		return Object.values(columnWidths)?.map((width, idx) => <col key={idx} style={{ width }} />);
+	};
+
+	const renderTableHeader = () => {
+		const columns = {
+			flag: t(FeatureFlags.TABLE_FLAG, { ns: i18Namespace.featureFlags }),
+			description: t(FeatureFlags.TABLE_DESCRIPTION, { ns: i18Namespace.featureFlags }),
+			enabled: t(FeatureFlags.TABLE_ENABLED, { ns: i18Namespace.featureFlags }),
+			roles: t(FeatureFlags.TABLE_ROLES, { ns: i18Namespace.featureFlags }),
+			clientType: t(FeatureFlags.TABLE_CLIENT_TYPE, { ns: i18Namespace.featureFlags }),
+			createdAt: t(FeatureFlags.TABLE_CREATED_AT, { ns: i18Namespace.featureFlags }),
+			actions: t(FeatureFlags.TABLE_ACTIONS, { ns: i18Namespace.featureFlags }),
+		};
+
+		return Object.entries(columns)?.map(([k, v]) => <td key={k}>{v}</td>);
+	};
+
+	const renderTableBody = (featureFlag: FeatureFlagApiItem) => {
+		const enabledStatus: StatusChipItem = featureFlag.enabled
+			? {
+					text: t(FeatureFlags.STATUS_ENABLED, { ns: i18Namespace.featureFlags }),
+					variant: 'green',
+				}
+			: {
+					text: t(FeatureFlags.STATUS_DISABLED, { ns: i18Namespace.featureFlags }),
+					variant: 'red',
+				};
+
+		const columns = {
+			flag: (
+				<Link to={route(ROUTES.admin.featureFlags.details.page, featureFlag.id)}>
+					{featureFlag.flag}
+				</Link>
+			),
+			description: featureFlag.description,
+			enabled: <StatusChip status={enabledStatus} />,
+			roles: featureFlag.roles?.length ? (
+				<UserRolesList userRoles={featureFlag.roles} />
+			) : (
+				<Text variant="body3-accent">-</Text>
+			),
+			clientType: <Text variant="body3-accent">{featureFlag.clientType}</Text>,
+			createdAt: (
+				<Text variant="body3-accent">{new Date(featureFlag.createdAt).toLocaleDateString()}</Text>
+			),
+		};
+
+		return Object.entries(columns)?.map(([k, v]) => <td key={k}>{v}</td>);
+	};
+
+	const navigate = useNavigate();
+
+	const renderActions = (featureFlag: FeatureFlagApiItem) => {
+		const menuItems: PopoverMenuItem[] = [
+			{
+				icon: <Icon icon="eye" size={24} />,
+				title: 'Посмотреть',
+				onClick: () => {
+					navigate(route(ROUTES.admin.featureFlags.details.page, featureFlag.id));
+				},
+			},
+			{
+				icon: <Icon icon="pen" size={24} />,
+				title: 'Редактировать',
+				onClick: () => {
+					navigate(`/admin/featureFlags/${featureFlag.id}/edit`);
+				},
+			},
+			{
+				icon: <Icon icon="trash" size={24} />,
+				title: 'Удалить',
+				onClick: () => {
+					console.log('delete', featureFlag.id);
+				},
+			},
+		];
+
+		return (
+			<Flex gap="4">
+				<Popover menuItems={menuItems}>
+					{({ onToggle }) => (
+						<IconButton
+							aria-label="actions"
+							form="square"
+							size="medium"
+							variant="tertiary"
+							icon={<Icon icon="dotsThreeVertical" size={20} />}
+							onClick={onToggle}
+						/>
+					)}
+				</Popover>
+			</Flex>
+		);
+	};
+
+	if (!featureFlags) {
+		return null;
+	}
+
+	return (
+		<Table
+			renderTableHeader={renderTableHeader}
+			renderTableBody={renderTableBody}
+			items={featureFlags}
+			renderActions={renderActions}
+			renderTableColumnWidths={renderTableColumnWidths}
+			hasCopyButton
+			selectedItems={selectedItems}
+			onSelectItems={onSelectItems}
+		/>
+	);
+};

--- a/src/shared/config/i18n/i18nTranslations.ts
+++ b/src/shared/config/i18n/i18nTranslations.ts
@@ -58,6 +58,7 @@ export enum Translation {
 	SIDEBAR_MENU_TOPICS = 'sidebar.menu.topics',
 	SIDEBAR_MENU_TASKS = 'sidebar.menu.tasks',
 	SIDEBAR_MENU_REFERRALS = 'sidebar.menu.referrals',
+	SIDEBAR_MENU_FEATURE_FLAGS = 'sidebar.menu.featureFlags',
 	KEYWORD_LABEL = 'keyword.label',
 	KEYWORD_PLACEHOLDER = 'keyword.placeholder',
 	KEYWORD_NOT_FOUND = 'keyword.not.found',
@@ -348,12 +349,25 @@ export enum Translation {
 	TOAST_AUTH_TELEGRAM_VERIFICATION_LINK_ERROR = 'toast.auth.telegram.verification.link.error.default',
 	TOAST_TOPIC_CREATE_SUCCESS = 'toast.topics.create.success',
 	TOAST_TOPIC_CREATE_FAILED = 'toast.topics.create.failed',
+	TOAST_TOPIC_CREATE_AUTH_UNAUTHORIZED = 'toast.topics.create.auth.unauthorized',
+	TOAST_TOPIC_CREATE_AUTH_USER_VERIFIED = 'toast.topics.create.auth.user.verified',
+	TOAST_TOPIC_CREATE_TOPIC_SKILL_NOT_FOUND = 'toast.topics.create.topic.skill.not_found',
+	TOAST_TOPIC_CREATE_TOPIC_TITLE_CONFLICT = 'toast.topics.create.topic.title.conflict',
+	TOAST_TOPIC_CREATE_TINIFY_COMPRESS_FAILED = 'toast.topics.create.tinify.compress.failed',
+	TOAST_TOPIC_CREATE_TINIFY_RESIZE_FAILED = 'toast.topics.create.tinify.resize.failed',
 	TOAST_TOPIC_DELETE_SINGLE_SUCCESS = 'toast.topics.delete.single.success',
 	TOAST_TOPIC_DELETE_SINGLE_FAILED = 'toast.topics.delete.single.failed',
 	TOAST_TOPIC_DELETE_MULTIPLE_SUCCESS = 'toast.topics.delete.multiple.success',
 	TOAST_TOPIC_DELETE_MULTIPLE_FAILED = 'toast.topics.delete.multiple.failed',
 	TOAST_TOPIC_EDIT_SUCCESS = 'toast.topics.edit.success',
 	TOAST_TOPIC_EDIT_FAILED = 'toast.topics.edit.failed',
+	TOAST_TOPIC_DELETE_SINGLE_IMAGE_URL_INVALID = 'toast.topics.delete.single.image.url_invalid',
+	TOAST_TOPIC_DELETE_AUTH_UNAUTHORIZED = 'toast.topics.delete.auth.unauthorized',
+	TOAST_TOPIC_DELETE_AUTH_USER_VERIFIED = 'toast.topics.delete.auth.user.verified',
+	TOAST_TOPIC_DELETE_AUTH_ROLES_AUTHOR_CAN_CHANGE_ONLY_OWN = 'toast.topics.delete.auth.roles.author.can.change.only.own',
+	TOAST_TOPIC_DELETE_SINGLE_NOTFOUND = 'toast.topics.delete.single.not_found',
+	TOAST_TOPIC_DELETE_SINGLE_IMAGE_NOT_FOUND = 'toast.topics.delete.single.image.not_found',
+	TOAST_TOPIC_DELETE_CONSTRAINT_KEY_VIOLATION = 'toast.topics.delete.constraint.foreign_key_violation',
 	TOAST_AUTH_TELEGRAM_UNAUTHORIZED = 'toast.auth.telegram.verification.link.error.unauthorized',
 	TOAST_AUTH_TELEGRAM_INVALID_DATA = 'toast.auth.telegram.verification.link.error.invalid.data',
 	TOAST_AUTH_TELEGRAM_DATA_OUTDATED = 'toast.auth.telegram.verification.link.error.data.outdated',
@@ -541,6 +555,21 @@ export enum Specializations {
 	EMPTY_DETAIL_DESCRIPTION = 'empty.detail.description',
 	EMPTY_DETAIL_BUTTON = 'empty.detail.button',
 	EMPTY_DETAIL_TITLE = 'empty.detail.title',
+}
+
+export enum FeatureFlags {
+	STUB_EMPTY_TITLE = 'stub.empty.featureFlags.title',
+	STUB_EMPTY_SUBTITLE = 'stub.empty.featureFlags.subtitle',
+	STUB_EMPTY_SUBMIT = 'stub.empty.featureFlags.submit',
+	TABLE_FLAG = 'table.featureFlags.flag',
+	TABLE_DESCRIPTION = 'table.featureFlags.description',
+	TABLE_ENABLED = 'table.featureFlags.enabled',
+	TABLE_ROLES = 'table.featureFlags.roles',
+	TABLE_CLIENT_TYPE = 'table.featureFlags.clientType',
+	TABLE_CREATED_AT = 'table.featureFlags.createdAt',
+	TABLE_ACTIONS = 'table.featureFlags.actions',
+	STATUS_ENABLED = 'status.featureFlags.enabled',
+	STATUS_DISABLED = 'status.featureFlags.disabled',
 }
 
 export enum Topics {
@@ -855,6 +884,10 @@ export enum Questions {
 	MODAL_MOVE_TO_EXIST_COLLECTION_TITLE = 'modal.move.to.exist.collection.title',
 	MODAL_MOVE_TO_EXIST_COLLECTION_BUTTON_OK = 'modal.move.to.exist.collection.button.ok',
 	MODAL_MOVE_TO_EXIST_COLLECTION_BUTTON_CANCEL = 'modal.move.to.exist.collection.button.cancel',
+
+	STUDY_STATUS_LEARNED = 'study.status.learned',
+	STUDY_STATUS_IN_PROGRESS = 'study.status.in.progress',
+	STUDY_STATUS_NOT_LEARNED = 'study.status.not.learned',
 }
 
 export enum InterviewHistory {
@@ -1425,6 +1458,7 @@ export enum TextEditor {
 export enum Guru {
 	BANNER_TITLE = 'banner.title',
 	BANNER_DESCRIPTION = 'banner.description',
+	NEW_BANNER_BUTTON = 'new.banner.button',
 }
 
 export enum Learning {


### PR DESCRIPTION
что сделал: 
1. добавил на страницу таблицы с фича-флагами рендер экшенс с переходом на страницу отдельного фича флага. на кнопку с удалением оставил заглушку в виде консоль лога 
2. создал отдельную страницу фича флага и разбил её на две - в одной враппер (проверил под ролью автор - пускает только админа), а в другой контент 
3. вынес тоггл по активности фичафлага в отдельную фичу: чтобы его можно было бы переиспользовать в компоненте таблицы с фичафлагами 
4. добавил в слайс по фичафлагам два метода - чтобы получить флаг по айди и чтобы поменять enabled, к последнему ещё добавил инвалидейт теги
5. добавил переводы на английский и русский 