### PR TITLE
YH-1691: fix step number rendering bug

### DIFF
--- a/src/shared/ui/Range/RangeSteps/RangeSteps.module.css
+++ b/src/shared/ui/Range/RangeSteps/RangeSteps.module.css
@@ -10,7 +10,11 @@
     justify-content: center;
     align-items: center;
     gap: 8px;
-  
+
+    .number {
+      white-space: nowrap;
+    }
+
     .dot {
       width: 3px;
       height: 3px;

--- a/src/shared/ui/Range/RangeSteps/RangeSteps.tsx
+++ b/src/shared/ui/Range/RangeSteps/RangeSteps.tsx
@@ -14,7 +14,7 @@ export const RangeSteps = () => {
 	for (let i = min; i <= max; i += step) {
 		steps.push(
 			<div key={i} className={styles['step']}>
-				<span>{i}</span>
+				<span className={styles['number']}>{i}</span>
 				<div className={styles['dot']}></div>
 			</div>,
 		);


### PR DESCRIPTION
Исправлен баг с некорректным переносом текста в номерах шагов.

- В shared компоненте `RangeSteps` для элементов `span` (с номерами/текстом шагов) добавлено CSS-свойство `white-space: nowrap;`.