### PR TITLE
feature/YH-1908: add topics filter to admin questions page

### DIFF
--- a/src/entities/question/model/types/filters.ts
+++ b/src/entities/question/model/types/filters.ts
@@ -11,11 +11,9 @@ export interface QuestionsFilterParams {
 	isMy?: boolean;
 	order?: SortOrder;
 	orderBy?: QuestionFilterOrderBy;
-	topics?: QuestionFilterTopic
+	topics?: number[];
 }
 
 export type QuestionFilterStatus = 'all' | 'learned' | 'not-learned' | 'favorite';
 
 export type QuestionFilterOrderBy = 'title' | 'complexity' | 'rate';
-
-export type QuestionFilterTopic = number[]

--- a/src/entities/question/model/types/filters.ts
+++ b/src/entities/question/model/types/filters.ts
@@ -11,8 +11,11 @@ export interface QuestionsFilterParams {
 	isMy?: boolean;
 	order?: SortOrder;
 	orderBy?: QuestionFilterOrderBy;
+	topics?: QuestionFilterTopic
 }
 
 export type QuestionFilterStatus = 'all' | 'learned' | 'not-learned' | 'favorite';
 
 export type QuestionFilterOrderBy = 'title' | 'complexity' | 'rate';
+
+export type QuestionFilterTopic = number[]

--- a/src/entities/question/model/types/question.ts
+++ b/src/entities/question/model/types/question.ts
@@ -95,6 +95,7 @@ export interface GetQuestionsListParamsRequest {
 	profileId?: string;
 	areFavorites?: boolean;
 	authorId?: string;
+	topics?: number[];
 }
 
 export type GetQuestionsListResponse = Response<Question[]>;

--- a/src/entities/topic/model/constants/topicConstants.ts
+++ b/src/entities/topic/model/constants/topicConstants.ts
@@ -1,3 +1,5 @@
+export const MAX_SHOWN_LIMIT_TOPICS = 5;
+
 export const topicApiUrl = {
 	getTopicsList: 'topics',
 	getTopicById: 'topics/:topicId',

--- a/src/entities/topic/ui/TopicFilterField/TopicFilterField.tsx
+++ b/src/entities/topic/ui/TopicFilterField/TopicFilterField.tsx
@@ -1,0 +1,85 @@
+import {QuestionFilterTopic} from "@/entities/question/model/types/filters";
+import {useTranslation} from "react-i18next";
+import {i18Namespace, Questions, Translation} from "@/shared/config";
+import {BaseFilterItem, BaseFilterSection} from "@/shared/ui/BaseFilterSection";
+import {useScreenSize} from "@/shared/libs";
+import {useEffect, useMemo, useState} from "react";
+import {MAX_SHOWN_LIMIT_TOPICS} from "@/entities/topic/model/constants/topicConstants";
+import {useGetTopicsListQuery} from "@/entities/topic";
+import {Flex} from "@/shared/ui/Flex";
+import {Button} from "@/shared/ui/Button";
+
+interface TopicFilterFieldProps {
+	onChangeTopics: (topics: number[]) => void;
+	selectedTopics? : QuestionFilterTopic,
+	selectedSkills?: number[];
+}
+
+export const TopicFilterField = ({
+																			onChangeTopics,
+																			selectedTopics = [],
+																			selectedSkills = [],
+																		}:TopicFilterFieldProps) => {
+	const { t } = useTranslation([i18Namespace.questions, i18Namespace.translation]);
+	
+	const { isMobile } = useScreenSize();
+	
+	const [showAll, setShowAll] = useState(false);
+	const [limit, setLimit] = useState(MAX_SHOWN_LIMIT_TOPICS);
+	
+	const { data: topicsData, isLoading } = useGetTopicsListQuery({
+		...(selectedSkills.length > 0 && { skillIds: selectedSkills }),
+		limit
+	})
+	
+	useEffect(() => {
+		if(isMobile || showAll){
+			setLimit((limit) => topicsData?.total ?? limit);
+				
+			} else {
+			setLimit(MAX_SHOWN_LIMIT_TOPICS)
+		}
+	}, [isMobile, showAll, topicsData?.total]);
+
+	const onToggleShowAll = () => setShowAll(prev => !prev);
+
+
+	const handleTopicClick = (id: number) => {
+		const isSelected = selectedTopics.includes(id);
+		const newTopics = isSelected 
+		? selectedTopics.filter(topicId => topicId !== id)
+			: [...selectedTopics, id]
+		onChangeTopics(newTopics.length ? newTopics : [])
+	}
+	
+	const topicItems: BaseFilterItem<number>[] | undefined = useMemo(
+		() => topicsData?.data?.map(({ id, title }) => ({
+			id,
+			title,
+			active: selectedTopics.includes(id),
+		})),
+		[topicsData?.data, selectedTopics]
+	)
+	if (isLoading || !topicItems) return null
+	
+	return (
+		<Flex direction='column' align='start' gap="8"> 
+			<BaseFilterSection 
+				title={t(Questions.TOPIC_TITLE)} 
+				data={topicItems} 
+				onClick={handleTopicClick}
+			/>
+			{!isMobile && topicsData && topicsData.total > MAX_SHOWN_LIMIT_TOPICS && (
+				<Button
+					variant='link'
+					onClick={onToggleShowAll}
+				>
+					{!showAll
+					? t(Translation.SHOW_ALL, { ns: i18Namespace.translation })
+					: t(Translation.HIDE, { ns: i18Namespace.translation })}
+				</Button>
+			)}
+		</Flex>
+	)
+	
+}

--- a/src/entities/topic/ui/TopicFilterField/TopicFilterField.tsx
+++ b/src/entities/topic/ui/TopicFilterField/TopicFilterField.tsx
@@ -1,85 +1,81 @@
-import {QuestionFilterTopic} from "@/entities/question/model/types/filters";
-import {useTranslation} from "react-i18next";
-import {i18Namespace, Questions, Translation} from "@/shared/config";
-import {BaseFilterItem, BaseFilterSection} from "@/shared/ui/BaseFilterSection";
-import {useScreenSize} from "@/shared/libs";
-import {useEffect, useMemo, useState} from "react";
-import {MAX_SHOWN_LIMIT_TOPICS} from "@/entities/topic/model/constants/topicConstants";
-import {useGetTopicsListQuery} from "@/entities/topic";
-import {Flex} from "@/shared/ui/Flex";
-import {Button} from "@/shared/ui/Button";
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { i18Namespace, Questions, Translation } from '@/shared/config';
+import { useScreenSize } from '@/shared/libs';
+import { BaseFilterItem, BaseFilterSection } from '@/shared/ui/BaseFilterSection';
+import { Button } from '@/shared/ui/Button';
+import { Flex } from '@/shared/ui/Flex';
+
+import { useGetTopicsListQuery } from '../../api/topicApi';
+import { MAX_SHOWN_LIMIT_TOPICS } from '../../model/constants/topicConstants';
 
 interface TopicFilterFieldProps {
 	onChangeTopics: (topics: number[]) => void;
-	selectedTopics? : QuestionFilterTopic,
+	selectedTopics?: number[];
 	selectedSkills?: number[];
 }
 
 export const TopicFilterField = ({
-																			onChangeTopics,
-																			selectedTopics = [],
-																			selectedSkills = [],
-																		}:TopicFilterFieldProps) => {
+	onChangeTopics,
+	selectedTopics = [],
+	selectedSkills = [],
+}: TopicFilterFieldProps) => {
 	const { t } = useTranslation([i18Namespace.questions, i18Namespace.translation]);
-	
+
 	const { isMobile } = useScreenSize();
-	
+
 	const [showAll, setShowAll] = useState(false);
 	const [limit, setLimit] = useState(MAX_SHOWN_LIMIT_TOPICS);
-	
+
 	const { data: topicsData, isLoading } = useGetTopicsListQuery({
 		...(selectedSkills.length > 0 && { skillIds: selectedSkills }),
-		limit
-	})
-	
+		limit,
+	});
+
 	useEffect(() => {
-		if(isMobile || showAll){
+		if (isMobile || showAll) {
 			setLimit((limit) => topicsData?.total ?? limit);
-				
-			} else {
-			setLimit(MAX_SHOWN_LIMIT_TOPICS)
+		} else {
+			setLimit(MAX_SHOWN_LIMIT_TOPICS);
 		}
 	}, [isMobile, showAll, topicsData?.total]);
 
-	const onToggleShowAll = () => setShowAll(prev => !prev);
-
+	const onToggleShowAll = () => setShowAll((prev) => !prev);
 
 	const handleTopicClick = (id: number) => {
 		const isSelected = selectedTopics.includes(id);
-		const newTopics = isSelected 
-		? selectedTopics.filter(topicId => topicId !== id)
-			: [...selectedTopics, id]
-		onChangeTopics(newTopics.length ? newTopics : [])
-	}
-	
+		const newTopics = isSelected
+			? selectedTopics.filter((topicId) => topicId !== id)
+			: [...selectedTopics, id];
+		onChangeTopics(newTopics.length ? newTopics : []);
+	};
+
 	const topicItems: BaseFilterItem<number>[] | undefined = useMemo(
-		() => topicsData?.data?.map(({ id, title }) => ({
-			id,
-			title,
-			active: selectedTopics.includes(id),
-		})),
-		[topicsData?.data, selectedTopics]
-	)
-	if (isLoading || !topicItems) return null
-	
+		() =>
+			topicsData?.data?.map(({ id, title }) => ({
+				id,
+				title,
+				active: selectedTopics.includes(id),
+			})),
+		[topicsData?.data, selectedTopics],
+	);
+	if (isLoading || !topicItems) return null;
+
 	return (
-		<Flex direction='column' align='start' gap="8"> 
-			<BaseFilterSection 
-				title={t(Questions.TOPIC_TITLE)} 
-				data={topicItems} 
+		<Flex direction="column" align="start" gap="8">
+			<BaseFilterSection
+				title={t(Questions.TOPIC_TITLE)}
+				data={topicItems}
 				onClick={handleTopicClick}
 			/>
 			{!isMobile && topicsData && topicsData.total > MAX_SHOWN_LIMIT_TOPICS && (
-				<Button
-					variant='link'
-					onClick={onToggleShowAll}
-				>
+				<Button variant="link" onClick={onToggleShowAll}>
 					{!showAll
-					? t(Translation.SHOW_ALL, { ns: i18Namespace.translation })
-					: t(Translation.HIDE, { ns: i18Namespace.translation })}
+						? t(Translation.SHOW_ALL, { ns: i18Namespace.translation })
+						: t(Translation.HIDE, { ns: i18Namespace.translation })}
 				</Button>
 			)}
 		</Flex>
-	)
-	
-}
+	);
+};

--- a/src/features/question/filterQuestions/model/hooks/useQuestionsFilters.ts
+++ b/src/features/question/filterQuestions/model/hooks/useQuestionsFilters.ts
@@ -17,6 +17,7 @@ export const useQuestionsFilters = (initialParams: QuestionsFilterParams) => {
 		Boolean(filters.specialization) ||
 		(filters.skills || []).length > 0 ||
 		(filters.rate || []).length > 0 ||
+		(filters.topics || []).length > 0 ||
 		(filters.complexity || []).length > 0 ||
 		(filters.status && filters.status !== 'all') ||
 		filters.isMy ||
@@ -38,6 +39,13 @@ export const useQuestionsFilters = (initialParams: QuestionsFilterParams) => {
 	const onChangeSkills = (skills: QuestionsFilterParams['skills']) => {
 		onFilterChange({
 			skills,
+			page: 1,
+		});
+	};
+
+	const onChangeTopics = (topics: QuestionsFilterParams['topics']) => {
+		onFilterChange({
+			topics: topics && topics.length > 0 ? topics : undefined,
 			page: 1,
 		});
 	};
@@ -78,6 +86,7 @@ export const useQuestionsFilters = (initialParams: QuestionsFilterParams) => {
 		onChangeSpecialization,
 		onChangePage,
 		onChangeSkills,
+		onChangeTopics,
 		onChangeComplexity,
 		onChangeRate,
 		onChangeStatus,

--- a/src/features/question/filterQuestions/ui/QuestionsFilters/QuestionsFilters.tsx
+++ b/src/features/question/filterQuestions/ui/QuestionsFilters/QuestionsFilters.tsx
@@ -15,6 +15,7 @@ import { SpecializationsListField } from '@/entities/specialization';
 import { QuestionRateFilter } from '../QuestionRateFilter/QuestionRateFilter';
 import { QuestionSortByFieldFilter } from '../QuestionSortByFieldFilter/QuestionSortByFieldFilter';
 import { QuestionStatusFilter } from '../QuestionStatusFilter/QuestionStatusFilter';
+import {TopicFilterField} from "@/entities/topic/ui/TopicFilterField/TopicFilterField";
 
 interface QuestionsFiltersProps {
 	filters: QuestionsFilterParams;
@@ -27,6 +28,7 @@ interface QuestionsFiltersProps {
 	onChangeIsMy?: (isMy?: QuestionsFilterParams['isMy']) => void;
 	onChangeOrder?: (order?: QuestionsFilterParams['order']) => void;
 	onChangeOrderBy?: (orderBy?: QuestionsFilterParams['orderBy']) => void;
+	onChangeTopics?: (topics?: QuestionsFilterParams['topics']) => void;
 }
 export const QuestionsFilters = ({
 	filters,
@@ -39,8 +41,9 @@ export const QuestionsFilters = ({
 	onChangeIsMy,
 	onChangeOrder,
 	onChangeOrderBy,
+																	 onChangeTopics
 }: QuestionsFiltersProps) => {
-	const { skills, rate, complexity, status, title, specialization, isMy, order, orderBy } = filters;
+	const { skills, rate, complexity, status, title, specialization, isMy, order, orderBy, topics } = filters;
 	const { t } = useTranslation(i18Namespace.questions);
 	const specializationId = useAppSelector(getSpecializationId);
 	const project = useCurrentProject();
@@ -66,6 +69,12 @@ export const QuestionsFilters = ({
 					selectedSpecialization={specialization}
 					onChangeSpecialization={onChangeSpecialization}
 				/>
+			)}
+			{project === 'admin' && onChangeTopics && (
+				<TopicFilterField 
+					onChangeTopics={onChangeTopics} 
+					selectedSkills={skills}
+					selectedTopics={topics} />
 			)}
 			<SkillsListField
 				selectedSkills={skills}

--- a/src/features/question/filterQuestions/ui/QuestionsFilters/QuestionsFilters.tsx
+++ b/src/features/question/filterQuestions/ui/QuestionsFilters/QuestionsFilters.tsx
@@ -11,11 +11,11 @@ import { getSpecializationId } from '@/entities/profile';
 import { ChooseQuestionComplexity, QuestionsFilterParams } from '@/entities/question';
 import { SkillsListField } from '@/entities/skill';
 import { SpecializationsListField } from '@/entities/specialization';
+import { TopicFilterField } from '@/entities/topic/ui/TopicFilterField/TopicFilterField';
 
 import { QuestionRateFilter } from '../QuestionRateFilter/QuestionRateFilter';
 import { QuestionSortByFieldFilter } from '../QuestionSortByFieldFilter/QuestionSortByFieldFilter';
 import { QuestionStatusFilter } from '../QuestionStatusFilter/QuestionStatusFilter';
-import {TopicFilterField} from "@/entities/topic/ui/TopicFilterField/TopicFilterField";
 
 interface QuestionsFiltersProps {
 	filters: QuestionsFilterParams;
@@ -41,9 +41,10 @@ export const QuestionsFilters = ({
 	onChangeIsMy,
 	onChangeOrder,
 	onChangeOrderBy,
-																	 onChangeTopics
+	onChangeTopics,
 }: QuestionsFiltersProps) => {
-	const { skills, rate, complexity, status, title, specialization, isMy, order, orderBy, topics } = filters;
+	const { skills, rate, complexity, status, title, specialization, isMy, order, orderBy, topics } =
+		filters;
 	const { t } = useTranslation(i18Namespace.questions);
 	const specializationId = useAppSelector(getSpecializationId);
 	const project = useCurrentProject();
@@ -71,10 +72,11 @@ export const QuestionsFilters = ({
 				/>
 			)}
 			{project === 'admin' && onChangeTopics && (
-				<TopicFilterField 
-					onChangeTopics={onChangeTopics} 
+				<TopicFilterField
+					onChangeTopics={onChangeTopics}
 					selectedSkills={skills}
-					selectedTopics={topics} />
+					selectedTopics={topics}
+				/>
 			)}
 			<SkillsListField
 				selectedSkills={skills}

--- a/src/pages/admin/question/questions/ui/QuestionsTablePage/QuestionsTablePage.tsx
+++ b/src/pages/admin/question/questions/ui/QuestionsTablePage/QuestionsTablePage.tsx
@@ -48,6 +48,7 @@ const QuestionsPage = () => {
 		onChangeIsMy,
 		onChangeOrder,
 		onChangeOrderBy,
+		onChangeTopics
 	} = useQuestionsFilters({
 		page: 1,
 	});
@@ -67,6 +68,7 @@ const QuestionsPage = () => {
 		orderBy: filters.orderBy,
 		order: filters.order,
 		authorId: filters.isMy ? userId : undefined,
+		topics: filters.topics,
 	});
 
 	const onSelectQuestions = (ids: SelectedAdminEntities) => {
@@ -139,6 +141,9 @@ const QuestionsPage = () => {
 		);
 	};
 
+	console.log('filters.topics:', filters.topics);
+	console.log('topics length:', filters.topics?.length);
+
 	return (
 		<PageWrapper
 			isLoading={isLoadingAllQuestions}
@@ -183,6 +188,7 @@ const QuestionsPage = () => {
 								onChangeOrder={onChangeOrder}
 								onChangeIsMy={onChangeIsMy}
 								onChangeOrderBy={onChangeOrderBy}
+								onChangeTopics={onChangeTopics}
 							/>
 						)}
 					/>

--- a/src/pages/admin/question/questions/ui/QuestionsTablePage/QuestionsTablePage.tsx
+++ b/src/pages/admin/question/questions/ui/QuestionsTablePage/QuestionsTablePage.tsx
@@ -48,7 +48,7 @@ const QuestionsPage = () => {
 		onChangeIsMy,
 		onChangeOrder,
 		onChangeOrderBy,
-		onChangeTopics
+		onChangeTopics,
 	} = useQuestionsFilters({
 		page: 1,
 	});
@@ -140,9 +140,6 @@ const QuestionsPage = () => {
 			</Popover>
 		);
 	};
-
-	console.log('filters.topics:', filters.topics);
-	console.log('topics length:', filters.topics?.length);
 
 	return (
 		<PageWrapper


### PR DESCRIPTION
Создан компонент TopicFilterField с множественным выбором тем (аналог SkillsListField)

Добавлен фильтр на страницу вопросов админки (QuestionsFilters)

Расширен хук useQuestionsFilters - добавлен onChangeTopics

Обновлён API-слой - добавлен параметр topics в типы запроса

Интегрирован запрос - параметр topics передаётся в useGetQuestionsListQuery