### PR TITLE
YH-1977: refactor SidebarCategoryMenuItem open Tooltip

### DIFF
--- a/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarCategoryMenuItem.tsx
+++ b/src/widgets/Sidebar/ui/SidebarMenuItem/SidebarCategoryMenuItem.tsx
@@ -25,7 +25,10 @@ const SidebarCategoryMenuItem = ({
 }: SidebarMenuCategoryItemProps) => {
 	const location = useLocation();
 
-	const [expanded, setExpanded] = useState(location.pathname.includes(menuItem.elements[0].route));
+	const initialExpandedState = menuItem.elements.some((elem) =>
+		location.pathname.includes(elem.route),
+	);
+	const [expanded, setExpanded] = useState(initialExpandedState);
 
 	const handleExpand = () => {
 		setExpanded((prev) => !prev);


### PR DESCRIPTION
Группа ссылок в сайбаре закрывалась при переходе на одну из этих ссылок второго уровня и обновлении страницы.

Исправлен баг, группа ссылок остается открытой при обновлении страницы в случае, если открыта одна из подссылок.