### PR TITLE
YH-1755: remove early return to fix error handling

### DIFF
--- a/src/pages/admin/specialization/specializationEdit/ui/SpecializationEditPage/SpecializationEditPage.tsx
+++ b/src/pages/admin/specialization/specializationEdit/ui/SpecializationEditPage/SpecializationEditPage.tsx
@@ -18,10 +18,6 @@ const SpecializationEditPage = () => {
 
 	const hasData = specialization && Object.keys(specialization).length > 0;
 
-	if (!specialization) {
-		return null;
-	}
-
 	const stubs: PageWrapperStubs = {
 		error: {
 			onClick: refetch,


### PR DESCRIPTION
Удалил ранний ретерн когда нет специализаций, так как он мешал работе по обработке ошибок в PageWrapper