### PR TITLE
YH-2015: added runtime feature flags in MainLayout and WithFeature

### DIFF
--- a/src/app/layouts/MainLayout/MainLayout.tsx
+++ b/src/app/layouts/MainLayout/MainLayout.tsx
@@ -18,7 +18,7 @@ import { NYBanner } from '@/shared/ui/NYBanner';
 import { NYModal } from '@/shared/ui/NYModal';
 
 import { listAdminRoles, useProfileQuery } from '@/entities/auth';
-import { WithFeature } from '@/entities/featureFlag';
+import { useGetFeatureFlagsListQuery, WithFeature } from '@/entities/featureFlag';
 import { getIsEmptySpecialization, getProfilesLength } from '@/entities/profile';
 
 import { Header } from '@/widgets/Header';
@@ -39,6 +39,7 @@ export const MainLayout = ({ sidebarItems, onlyAdmin }: MainLayoutProps) => {
 	const { isOpen, onOpen, onClose } = useModal();
 	const isOpenNYBanner = getFromLS(LS_BANNER_NY_DASHBOARD_KEY);
 	const isOpenNYModal = getFromLS(LS_MODAL_NY_DASHBOARD_KEY);
+	useGetFeatureFlagsListQuery({ clientType: 'WEB' });
 
 	const location = useLocation();
 

--- a/src/app/providers/store/config.ts
+++ b/src/app/providers/store/config.ts
@@ -3,6 +3,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { baseApi, createReduxStore, State } from '@/shared/config';
 
 import { refreshMiddleware } from '@/entities/auth';
+import { featureFlagReducer } from '@/entities/featureFlag';
 import { profileReducer } from '@/entities/profile';
 import { activeQuizSlice } from '@/entities/quiz';
 import { activeSubscriptionSlice } from '@/entities/subscription';
@@ -39,6 +40,7 @@ export const reducers = {
 	topicsPage: topicsPageReducer,
 	tasksTablePage: tasksTablePageReducer,
 	referralLinksPage: referralLinksPageReducer,
+	featureFlag: featureFlagReducer,
 };
 
 export const getStore = (initialState?: State) =>

--- a/src/entities/featureFlag/index.ts
+++ b/src/entities/featureFlag/index.ts
@@ -14,3 +14,5 @@ export { useGetFeatureFlagsListQuery, useGetFeatureFlagByIdQuery } from './api/f
 export { featureFlagHandlers } from './api/__mocks__';
 export { FeatureFlagForm } from './ui/FeatureFlagForm/FeatureFlagForm';
 export { clientTypes } from './model/constants/featureFlags';
+export { featureFlagReducer } from './model/slices/featureFlagSlice';
+export type { FeatureFlagState } from './model/slices/featureFlagSlice';

--- a/src/entities/featureFlag/model/selectors/featureFlagSelectors.ts
+++ b/src/entities/featureFlag/model/selectors/featureFlagSelectors.ts
@@ -1,0 +1,5 @@
+import { State } from '@/shared/config';
+
+import { Flag } from '../types/featureFlag';
+
+export const getFeatureFlag = (flag: Flag) => (state: State) => state.featureFlag[flag];

--- a/src/entities/featureFlag/model/slices/featureFlagSlice.ts
+++ b/src/entities/featureFlag/model/slices/featureFlagSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { featureFlagApi } from '../../api/featureFlagApi';
+import { FeatureFlagApiItem, Flag } from '../types/featureFlag';
+
+export type FeatureFlagState = Record<Flag, FeatureFlagApiItem>;
+
+const initialState: FeatureFlagState = {};
+
+export const featureFlagSlice = createSlice({
+	name: 'featureFlag',
+	initialState,
+	reducers: {},
+	extraReducers: (builder) => {
+		builder.addMatcher(
+			featureFlagApi.endpoints.getFeatureFlagsList.matchFulfilled,
+			(state, { payload }) => {
+				payload.data.forEach((item: FeatureFlagApiItem) => {
+					state[item.flag] = item;
+				});
+			},
+		);
+	},
+});
+
+export const featureFlagReducer = featureFlagSlice.reducer;

--- a/src/entities/featureFlag/model/types/featureFlag.ts
+++ b/src/entities/featureFlag/model/types/featureFlag.ts
@@ -24,9 +24,11 @@ export type GetFeatureFlagsListResponse = Response<FeatureFlagApiItem[]>;
 
 export type GetFeatureFlagByIdResponse = FeatureFlagApiItem;
 
+export type Flag = string;
+
 export interface FeatureFlagApiItem {
 	id: string;
-	flag: string;
+	flag: Flag;
 	enabled: boolean;
 	description: string;
 	roles: RoleName[];

--- a/src/entities/featureFlag/ui/WithFeature/WithFeature.tsx
+++ b/src/entities/featureFlag/ui/WithFeature/WithFeature.tsx
@@ -5,6 +5,7 @@ import { useAppSelector } from '@/shared/libs';
 import { getUserRoles } from '@/entities/profile/@x/featureFlag';
 
 import { featureFlags } from '../../model/constants/featureFlags';
+import { getFeatureFlag } from '../../model/selectors/featureFlagSelectors';
 import { FeatureFlagType } from '../../model/types/featureFlag';
 
 interface WithFeatureProps {
@@ -16,12 +17,17 @@ interface WithFeatureProps {
 
 export const WithFeature = ({ featureId, fallback = null, children }: WithFeatureProps) => {
 	const userRoles = useAppSelector(getUserRoles);
-	const hasRole = featureFlags[featureId].roles
-		? userRoles.some((role) => featureFlags[featureId].roles?.includes(role))
-		: true;
-	const isEnabled = featureFlags[featureId].enabled;
+	const featureFlagFromStore = useAppSelector(getFeatureFlag(featureId));
+	const featureFlag = featureFlagFromStore || featureFlags[featureId];
 
-	if (!isEnabled || !hasRole) return <>{fallback}</>;
+	if (!featureFlag) return <>{fallback}</>;
+
+	const hasRole = featureFlag.roles
+		? userRoles.some((role) => featureFlag.roles.includes(role))
+		: true;
+	const isEnabled = featureFlag.enabled;
+
+	if (!hasRole || !isEnabled) return <>{fallback}</>;
 
 	return <>{children}</>;
 };

--- a/src/shared/config/redux/State.ts
+++ b/src/shared/config/redux/State.ts
@@ -1,5 +1,6 @@
 import { baseApi } from '@/shared/config';
 
+import { FeatureFlagState } from '@/entities/featureFlag';
 import { ProfileState } from '@/entities/profile';
 import { ActiveQuizState } from '@/entities/quiz';
 import { ActiveSubscriptionState } from '@/entities/subscription';
@@ -31,4 +32,5 @@ export interface State {
 	topicsPage: TopicsPageState;
 	tasksTablePage: TasksTablePageState;
 	referralLinksPage: ReferralLinksPageState;
+	featureFlag: FeatureFlagState;
 }


### PR DESCRIPTION
Что сделано

- Добавлен вызов GET /feature-flags в MainLayout с параметром clientType=WEB
- Добавлен redux-слайс featureFlagSlice и подключен в корневой store и State.
- Настроена синхронизация ответа RTK Query в redux через extraReducers
- Изменена логика проверки WithFeature для приоритета runtime флагов над моками

Дополнительные изменения
- поле flag из типа FeatureFlagApiItem вынесено в отдельный тип Flag


