### PR TITLE
YH-2198: add a subscription check on the UsersRatingPage and links in the UsersRatingTable

### DIFF
--- a/src/pages/analytics/usersRating/ui/UsersRatingPage/UsersRatingPage.tsx
+++ b/src/pages/analytics/usersRating/ui/UsersRatingPage/UsersRatingPage.tsx
@@ -5,7 +5,7 @@ import { i18Namespace, Analytics } from '@/shared/config';
 import { useAppSelector, useScreenSize } from '@/shared/libs';
 import { Flex } from '@/shared/ui/Flex';
 
-import { getSpecializationId, getProfileId } from '@/entities/profile';
+import { getSpecializationId, getProfileId, getHasPremiumAccess } from '@/entities/profile';
 import {
 	useGetUserProfilePositionQuery,
 	useGetUsersRatingQuery,
@@ -26,6 +26,7 @@ export const UsersRatingPage = () => {
 	const { isMobile } = useScreenSize();
 
 	const profileId = useAppSelector(getProfileId);
+	const hasPremiumAccess = useAppSelector(getHasPremiumAccess);
 	const specializationId = useAppSelector(getSpecializationId);
 	const { filters, onChangePage, onResetFilters, onChangeSpecialization } = useAnalyticFilters({
 		specialization: specializationId,
@@ -59,7 +60,7 @@ export const UsersRatingPage = () => {
 		isError: isCurrentUserRatingError,
 		isLoading: isCurrentUserRatingLoading,
 		refetch: currentUserRatingRefetch,
-	} = useGetUserProfilePositionQuery(profileId);
+	} = useGetUserProfilePositionQuery(profileId, { skip: !hasPremiumAccess });
 
 	const usersOnPage = ratingData?.data ?? [];
 	const maxRating = statsData?.allQuestions ?? 0;

--- a/src/pages/analytics/usersRating/ui/UsersRatingTable/UsersRatingTable.tsx
+++ b/src/pages/analytics/usersRating/ui/UsersRatingTable/UsersRatingTable.tsx
@@ -48,7 +48,7 @@ export const UsersRatingTable = ({
 		return {
 			id: rankedUser.username,
 			place: rankedUser.place,
-			user: <UsersTitle rankedUser={rankedUser} isLink={false} />,
+			user: <UsersTitle rankedUser={rankedUser} isLink={true} />,
 			avatarUrl: rankedUser.avatarUrl,
 			studiedQuestions: `${rankedUser.ratingPoints * 10}/${maxRating}`,
 			progress: <UsersRatingProgressBar rankedUser={rankedUser} maxRating={maxRating} />,


### PR DESCRIPTION
- Добавлена проверка hasPremiumAccess для запроса [useGetUserProfilePositionQuery](https://api.yeatwork.ru/api#/ratings/RatingsController_getUserPosition) в UsersRatingPage, теперь запрос вызывается только при наличии активной подписки
- Добавлены ссылки для столбца с ником пользователя в UsersRatingTable

Задача: https://tracker.yandex.ru/YH-2198