### PR TITLE
YH-2228: add validation for required subscription fields

### DIFF
--- a/src/features/subscriptions/subscribe/model/validation/subscriptionAgreeSchema.ts
+++ b/src/features/subscriptions/subscribe/model/validation/subscriptionAgreeSchema.ts
@@ -11,6 +11,13 @@ export const subscriptionAgreeSchema: yup.ObjectSchema<SubscriptionAgreeFormValu
 			.string()
 			.email(() => i18n.t(Translation.VALIDATION_EMAIL))
 			.required(() => i18n.t(Translation.VALIDATION_REQUIRED)),
-		isOfferAgreed: yup.boolean().required(() => i18n.t(Translation.VALIDATION_REQUIRED)),
-		isConsentAgreed: yup.boolean().required(() => i18n.t(Translation.VALIDATION_REQUIRED)),
+		isOfferAgreed: yup
+			.boolean()
+			.oneOf([true], () => i18n.t(Translation.VALIDATION_REQUIRED))
+			.required(() => i18n.t(Translation.VALIDATION_REQUIRED)),
+
+		isConsentAgreed: yup
+			.boolean()
+			.oneOf([true], () => i18n.t(Translation.VALIDATION_REQUIRED))
+			.required(() => i18n.t(Translation.VALIDATION_REQUIRED)),
 	});

--- a/src/features/subscriptions/subscribe/ui/SubscribeModal/SubscribeModal.tsx
+++ b/src/features/subscriptions/subscribe/ui/SubscribeModal/SubscribeModal.tsx
@@ -43,12 +43,18 @@ export const SubscribeModal = ({ isOpen, onClose, subscriptionId }: SubscribeMod
 		mode: 'onTouched',
 		defaultValues: {
 			email: profile.email ?? '',
+			isOfferAgreed: false,
+			isConsentAgreed: false,
 		},
 	});
 
 	const { control, trigger, watch } = methods;
 
 	const email = watch('email');
+	const isOfferAgreed = watch('isOfferAgreed');
+	const isConsentAgreed = watch('isConsentAgreed');
+
+	const isSubsribeDisabled = !isOfferAgreed || !isConsentAgreed;
 
 	const offerAgreementParts = parseI18nText(
 		t(Subscription.SUBSCRIBE_MODAL_PRIVACY_OFFER_AGREEMENT),
@@ -148,7 +154,7 @@ export const SubscribeModal = ({ isOpen, onClose, subscriptionId }: SubscribeMod
 							</FormControl>
 						</Flex>
 					</Flex>
-					<Button size="large" fullWidth onClick={handleSubmit}>
+					<Button size="large" fullWidth onClick={handleSubmit} disabled={isSubsribeDisabled}>
 						{t(Subscription.SUBSCRIBE_MODAL_BUTTON)}
 					</Button>
 				</Flex>


### PR DESCRIPTION
YH-2228

## Changes

- Added validation for required subscription fields.
- Disabled the Subscribe button until both required checkboxes are selected.
- Prevented payment navigation without the required agreements.