### PR TITLE
YH-2313: Added unit test for QuestionStudyStatus component

### DIFF
--- a/src/entities/question/ui/QuestionStudyStatus/QuestionStudyStatus.test.tsx
+++ b/src/entities/question/ui/QuestionStudyStatus/QuestionStudyStatus.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from '@testing-library/react';
+
+import { Questions, i18nForJest } from '@/shared/config';
+import { renderComponent } from '@/shared/libs';
+import type { StatusChipVariant } from '@/shared/ui/StatusChip';
+import { statusChipTestIds } from '@/shared/ui/StatusChip/constants';
+
+import { StudyStatus } from '../../lib/getStudyStatus';
+
+import { QuestionStudyStatus } from './QuestionStudyStatus';
+
+const testStatuses: {
+	status: StudyStatus;
+	variant: StatusChipVariant;
+	translation: string;
+}[] = [
+	{
+		status: 'learned',
+		variant: 'green',
+		translation: Questions.STUDY_STATUS_LEARNED,
+	},
+	{
+		status: 'in-progress',
+		variant: 'yellow',
+		translation: Questions.STUDY_STATUS_IN_PROGRESS,
+	},
+	{
+		status: 'not-learned',
+		variant: 'red',
+		translation: Questions.STUDY_STATUS_NOT_LEARNED,
+	},
+];
+
+describe('QuestionStudyStatus component', () => {
+	describe.each(testStatuses)('For $status status', ({ status, variant, translation }) => {
+		beforeEach(() => {
+			renderComponent(<QuestionStudyStatus status={status} />);
+		});
+
+		test('applies correct variant class', () => {
+			expect(screen.getByTestId(statusChipTestIds.statusChip)).toHaveClass(`variant-${variant}`);
+		});
+
+		test('displays correct text content', () => {
+			expect(screen.getByTestId(statusChipTestIds.statusChipText)).toHaveTextContent(
+				i18nForJest.t(translation),
+			);
+		});
+	});
+});

--- a/src/entities/question/ui/QuestionStudyStatus/QuestionStudyStatus.test.tsx
+++ b/src/entities/question/ui/QuestionStudyStatus/QuestionStudyStatus.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { Questions, i18nForJest } from '@/shared/config';
 import { renderComponent } from '@/shared/libs';
 import type { StatusChipVariant } from '@/shared/ui/StatusChip';
-import { statusChipTestIds } from '@/shared/ui/StatusChip/constants';
+import { statusChipTestIds } from '@/shared/ui/StatusChip';
 
 import { StudyStatus } from '../../lib/getStudyStatus';
 

--- a/src/entities/question/ui/QuestionStudyStatus/QuestionStudyStatus.tsx
+++ b/src/entities/question/ui/QuestionStudyStatus/QuestionStudyStatus.tsx
@@ -9,25 +9,25 @@ interface QuestionStudyStatusProps {
 	status: StudyStatus;
 }
 
+const variantMap: Record<StudyStatus, StatusChipVariant> = {
+	learned: 'green',
+	'in-progress': 'yellow',
+	'not-learned': 'red',
+};
+
+const labels: Record<StudyStatus, string> = {
+	learned: Questions.STUDY_STATUS_LEARNED,
+	'in-progress': Questions.STUDY_STATUS_IN_PROGRESS,
+	'not-learned': Questions.STUDY_STATUS_NOT_LEARNED,
+};
+
 export const QuestionStudyStatus = ({ status }: QuestionStudyStatusProps) => {
 	const { t } = useTranslation(i18Namespace.questions);
-
-	const variantMap: Record<StudyStatus, StatusChipVariant> = {
-		learned: 'green',
-		'in-progress': 'yellow',
-		'not-learned': 'red',
-	};
-
-	const labels = {
-		learned: t(Questions.STUDY_STATUS_LEARNED),
-		'in-progress': t(Questions.STUDY_STATUS_IN_PROGRESS),
-		'not-learned': t(Questions.STUDY_STATUS_NOT_LEARNED),
-	};
 
 	return (
 		<StatusChip
 			status={{
-				text: labels[status],
+				text: t(labels[status]),
 				variant: variantMap[status],
 			}}
 			size="small"

--- a/src/shared/ui/StatusChip/index.ts
+++ b/src/shared/ui/StatusChip/index.ts
@@ -1,5 +1,7 @@
 export { StatusChip } from './StatusChip';
 export { StatusChipSkeleton } from './StatusChip.skeleton';
+export { statusChipTestIds } from './constants';
+
 export type {
 	StatusChipItem,
 	StatusChipVariant,


### PR DESCRIPTION
Добавлен unit-тест для компонента QuestionStudyStatus.
Также добавлен экспорт statusChipTestIds через index.ts папки  StatusChip   для соблюдения FSD-правил и исключения прямого импорта из внутренних файлов.
<img width="694" height="306" alt="image" src="https://github.com/user-attachments/assets/71bc38a7-d890-47b1-8914-e8f71a9a0e18" />
