### PR TITLE
YH-2310: add mock request for deleteTask

### DIFF
--- a/src/app/msw/handlers.ts
+++ b/src/app/msw/handlers.ts
@@ -43,6 +43,7 @@ import { specializationDeleteHandlers } from '@/features/specialization/deleteSp
 import { specializationEditHandlers } from '@/features/specialization/editSpecialization';
 import { paymentsIdHandlers } from '@/features/subscriptions/subscribe';
 import { taskCreateHandlers } from '@/features/task/createTask';
+import { deleteTaskHandlers } from '@/features/task/deleteTask';
 import { createTopicHandlers } from '@/features/topics/createTopics';
 import { topicDeleteHandlers } from '@/features/topics/deleteTopic';
 import { topicEditHandlers } from '@/features/topics/editTopic';
@@ -95,4 +96,5 @@ export const handlers = [
 	...referralLinkEditHandlers,
 	...taskHandlers,
 	...taskCreateHandlers,
+	...deleteTaskHandlers,
 ];

--- a/src/features/task/deleteTask/api/__mocks__/deleteTaskMock.ts
+++ b/src/features/task/deleteTask/api/__mocks__/deleteTaskMock.ts
@@ -1,0 +1,20 @@
+import { http, HttpResponse } from 'msw';
+
+import { tasksMock } from '@/entities/task';
+
+import { deleteTaskApiUrls } from '../../model/constants/deleteTaskConstants';
+
+export const deleteTaskMock = http.delete<{ taskId: string }>(
+	`${process.env.API_URL}${deleteTaskApiUrls.deleteTask}`,
+	({ params }) => {
+		const { taskId } = params;
+		const foundIndexTask = tasksMock.findIndex((task) => task.id === taskId);
+
+		if (foundIndexTask === -1) {
+			return HttpResponse.json({ message: 'Task is not found' }, { status: 404 });
+		}
+
+		tasksMock.splice(foundIndexTask, 1);
+		return new HttpResponse(null, { status: 200 });
+	},
+);

--- a/src/features/task/deleteTask/api/__mocks__/deleteTaskMock.ts
+++ b/src/features/task/deleteTask/api/__mocks__/deleteTaskMock.ts
@@ -1,20 +1,28 @@
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse, DefaultBodyType } from 'msw';
 
 import { tasksMock } from '@/entities/task';
 
 import { deleteTaskApiUrls } from '../../model/constants/deleteTaskConstants';
 
-export const deleteTaskMock = http.delete<{ taskId: string }>(
-	`${process.env.API_URL}${deleteTaskApiUrls.deleteTask}`,
-	({ params }) => {
-		const { taskId } = params;
-		const foundIndexTask = tasksMock.findIndex((task) => task.id === taskId);
+export const deleteTaskMock = http.delete<
+	{ taskId: string },
+	DefaultBodyType,
+	ApiErrorData<string>
+>(`${process.env.API_URL}${deleteTaskApiUrls.deleteTask}`, ({ params }) => {
+	const { taskId } = params;
+	const foundIndexTask = tasksMock.findIndex((task) => task.id === taskId);
 
-		if (foundIndexTask === -1) {
-			return HttpResponse.json({ message: 'Task is not found' }, { status: 404 });
-		}
+	if (foundIndexTask === -1) {
+		return HttpResponse.json(
+			{
+				message: 'task.task.not_found',
+				statusCode: 404,
+				description: 'Task not found',
+			},
+			{ status: 404 },
+		);
+	}
 
-		tasksMock.splice(foundIndexTask, 1);
-		return new HttpResponse(null, { status: 200 });
-	},
-);
+	tasksMock.splice(foundIndexTask, 1);
+	return new HttpResponse(null, { status: 204 });
+});

--- a/src/features/task/deleteTask/api/__mocks__/index.ts
+++ b/src/features/task/deleteTask/api/__mocks__/index.ts
@@ -1,0 +1,3 @@
+import { deleteTaskMock } from './deleteTaskMock';
+
+export const deleteTaskHandlers = [deleteTaskMock];

--- a/src/features/task/deleteTask/index.ts
+++ b/src/features/task/deleteTask/index.ts
@@ -1,2 +1,3 @@
 export { DeleteTaskButton } from './ui/DeleteTaskButton/DeleteTaskButton';
 export { DeleteTaskButtonSkeleton } from './ui/DeleteTaskButton/DeleteTaskButton.skeleton';
+export { deleteTaskHandlers } from './api/__mocks__/index';


### PR DESCRIPTION
Ссылка на задачу - https://tracker.yandex.ru/YH-2310.

1. Был добавлен моковый обработчик для удаления задачи

1.1 Создан src/features/task/deleteTask/api/__mocks__/deleteTaskMock.ts - перехватывает DELETE-запрос на удаление задачи, ищет задачу по id в tasksMock, удаляет при наличии, возвращает 404 при отсутствии

1.2  Создан src/features/task/deleteTask/api/__mocks__/index.ts - экспорт deleteTaskHandlers

1.3 Обновлен src/features/task/deleteTask/index.ts - добавлен экспорт deleteTaskHandlers

1.4 Обновлен src/app/msw/handlers.ts — deleteTaskHandlers добавлен в общий список обработчиков

Как проверялось:

1. Проект был запущен в mock режиме

2. Удаление тестировалось вручную, через таблицу задач в админке 

3. DELETE запрос перехватывался MSW и возвращает статус 200 

<img width="964" height="112" alt="image" src="https://github.com/user-attachments/assets/430becfe-c733-4216-b759-e1363711cff5" />


4. Задача корректно удаляется из tasksMock