### PR TITLE
YH-2217: fix skill create/edit page title text, font-size and spacing

### DIFF
--- a/public/locales/ru/skill.json
+++ b/public/locales/ru/skill.json
@@ -28,7 +28,7 @@
 	"empty": "Нет навыков",
 	"image.src": "Ссылка на картинку",
 	"create.page.title": "Создание навыка",
-	"edit.page.title": "Изменение навыка",
+	"edit.page.title": "Редактирование навыка",
 	"my.skills.title": "Мои навыки",
 	"stub": {
 		"empty": {

--- a/src/entities/skill/ui/SkillForm/SkillForm.module.css
+++ b/src/entities/skill/ui/SkillForm/SkillForm.module.css
@@ -1,6 +1,6 @@
 
 .main-title {
-  margin-bottom: 28px;
+  margin-bottom: 32px;
 }
 
 .textarea {

--- a/src/entities/skill/ui/SkillForm/SkillForm.tsx
+++ b/src/entities/skill/ui/SkillForm/SkillForm.tsx
@@ -42,7 +42,7 @@ export const SkillForm = ({ isEdit, imageSrc }: SkillFormProps) => {
 
 	return (
 		<>
-			<Text variant="body5-strong" className={styles['main-title']}>
+			<Text variant="body6" className={styles['main-title']}>
 				{isEdit ? t(Skills.EDIT_PAGE_TITLE) : t(Skills.CREATE_PAGE_TITLE)}
 			</Text>
 			<Flex direction="column" gap="60">


### PR DESCRIPTION
Задача - https://tracker.yandex.ru/YH-2217

Исправлены заголовки страниц создания/редактирования навыка в соответствии с задачей:

- Текст заголовка редактирования изменён с "Изменение навыка" на "Редактирование навыка" (public/locales/ru/skill.json)
- Размер шрифта заголовка увеличен с 20px до 24px (вариант Text изменён с body5-strong на body6)
- Отступ между заголовком и формой увеличен с 28px до 32px (SkillForm.module.css)
