### PR TITLE
YH-2338: migrated SkillsTable to TableV2 component

### DIFF
--- a/src/app/providers/router/routeConfig.tsx
+++ b/src/app/providers/router/routeConfig.tsx
@@ -419,7 +419,7 @@ export const router = createBrowserRouter([
 						element: <SkillEditPage />,
 					},
 					{
-						path: ROUTES.admin.skills.detail.route,
+						path: ROUTES.admin.skills.details.route,
 						element: <SkillDetailPage />,
 					},
 				],

--- a/src/features/skill/createSkill/api/createSkillApi.ts
+++ b/src/features/skill/createSkill/api/createSkillApi.ts
@@ -18,7 +18,7 @@ export const createSkillApi = baseApi.injectEndpoints({
 				try {
 					const result = await queryFulfilled;
 					const typedExtra = extra as ExtraArgument;
-					typedExtra.navigate(route(ROUTES.admin.skills.detail.page, result.data.id));
+					typedExtra.navigate(route(ROUTES.admin.skills.details.page, result.data.id));
 					toast.success(i18n.t(Translation.TOAST_SKILL_CREATE_SUCCESS));
 				} catch (error) {
 					toast.error(i18n.t(handleApiError(error, getCreateSkillApiErrorMessage)));

--- a/src/features/skill/deleteSkill/index.ts
+++ b/src/features/skill/deleteSkill/index.ts
@@ -1,2 +1,3 @@
 export { DeleteSkillButton } from './ui/DeleteSkillButton/DeleteSkillButton';
 export { skillDeleteHandlers } from './api/__mocks__';
+export { useDeleteSkillMutation } from './api/deleteSkillApi';

--- a/src/features/skill/editSkill/api/editSkillApi.ts
+++ b/src/features/skill/editSkill/api/editSkillApi.ts
@@ -18,7 +18,7 @@ const editSkillApi = baseApi.injectEndpoints({
 				try {
 					const result = await queryFulfilled;
 					const typedExtra = extra as ExtraArgument;
-					typedExtra.navigate(route(ROUTES.admin.skills.detail.page, result.data.id));
+					typedExtra.navigate(route(ROUTES.admin.skills.details.page, result.data.id));
 					toast.success(i18n.t(Translation.TOAST_SKILL_EDIT_SUCCESS));
 				} catch (error) {
 					toast.error(i18n.t(Translation.TOAST_SKILL_EDIT_FAILED));

--- a/src/pages/admin/question/questions/ui/QuestionsTable/QuestionsTable.tsx
+++ b/src/pages/admin/question/questions/ui/QuestionsTable/QuestionsTable.tsx
@@ -84,7 +84,7 @@ export const QuestionsTable = ({
 			width: '15%',
 			cell: ({ row }) => (
 				<TableCellEntityList
-					url={ROUTES.admin.skills.detail.page}
+					url={ROUTES.admin.skills.details.page}
 					items={row.skills}
 					showCount={SKILL_SHOW_COUNT}
 				/>

--- a/src/pages/admin/skill/skills/ui/SkillsTable/SkillsTable.tsx
+++ b/src/pages/admin/skill/skills/ui/SkillsTable/SkillsTable.tsx
@@ -44,7 +44,7 @@ export const SkillsTable = ({ skills, selectedSkills, onSelectSkills }: SkillsTa
 			specializations: skill.specializations,
 			description: skill.description,
 			author: skill.createdBy?.username ?? '-',
-			createdAt: skill.createdAt,
+			createdAt: skill.createdAt ? formatDate(new Date(skill.createdAt), 'dd.MM.yyyy') : '',
 		})) ?? [];
 
 	const columns: Array<TableColumn<SkillTableRow>> = [
@@ -99,9 +99,6 @@ export const SkillsTable = ({ skills, selectedSkills, onSelectSkills }: SkillsTa
 			id: 'createdAt',
 			header: t(Skills.CREATED_AT),
 			width: '15%',
-			cell: ({ row }) => (
-				<>{row.createdAt ? formatDate(new Date(row.createdAt), 'dd.MM.yyyy') : ''}</>
-			),
 		},
 	];
 

--- a/src/pages/admin/skill/skills/ui/SkillsTable/SkillsTable.tsx
+++ b/src/pages/admin/skill/skills/ui/SkillsTable/SkillsTable.tsx
@@ -1,23 +1,30 @@
+import { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 
 import { Skills, Translation, i18Namespace, ROUTES } from '@/shared/config';
 import { formatDate, route, SelectedAdminEntities } from '@/shared/libs';
-import { Flex } from '@/shared/ui/Flex';
-import { Icon } from '@/shared/ui/Icon';
-import { IconButton } from '@/shared/ui/IconButton';
 import { ImageWithWrapper } from '@/shared/ui/ImageWithWrapper';
-import { Popover, PopoverMenuItem } from '@/shared/ui/Popover';
-import { Table } from '@/shared/ui/Table';
 import { TableCellEntityList } from '@/shared/ui/TableCellEntityList';
 import { TableCellLink } from '@/shared/ui/TableCellLink';
 import { TableCellWithTooltip } from '@/shared/ui/TableCellWithTooltip';
+import { TableV2 } from '@/shared/ui/TableV2';
+import { type TableColumn, type TableRowId } from '@/shared/ui/TableV2';
 
 import { Skill } from '@/entities/skill';
 
-import { DeleteSkillButton } from '@/features/skill/deleteSkill';
+import { useDeleteSkillMutation } from '@/features/skill/deleteSkill';
 
 import styles from './SkillsTable.module.css';
+interface SkillTableRow {
+	id: number;
+	imageSrc: string;
+	disabled?: boolean;
+	title: string;
+	specializations: Skill['specializations'];
+	description: string;
+	author: string;
+	createdAt: string;
+}
 
 interface SkillsTableProps {
 	skills?: Skill[];
@@ -26,117 +33,112 @@ interface SkillsTableProps {
 }
 
 export const SkillsTable = ({ skills, selectedSkills, onSelectSkills }: SkillsTableProps) => {
-	const navigate = useNavigate();
 	const { t } = useTranslation([i18Namespace.skill, i18Namespace.translation]);
+	const [deleteSkill] = useDeleteSkillMutation();
 
-	const renderTableColumnWidths = () => {
-		const columnWidths = {
-			imageSrc: '10%',
-			title: '10%',
-			specializations: '15%',
-			description: 'auto',
-			author: '10%',
-			createdAt: '15%',
-		};
+	const tableData: SkillTableRow[] =
+		skills?.map((skill) => ({
+			id: skill.id,
+			imageSrc: skill.imageSrc ?? '',
+			title: skill.title,
+			specializations: skill.specializations,
+			description: skill.description,
+			author: skill.createdBy?.username ?? '-',
+			createdAt: skill.createdAt,
+		})) ?? [];
 
-		return Object.values(columnWidths)?.map((width, idx) => <col key={idx} style={{ width }} />);
-	};
-
-	const renderTableHeader = () => {
-		const columns = {
-			imageSrc: t(Skills.ICON_TITLE_SHORT),
-			title: t(Skills.TITLE_SHORT),
-			specializations: t(Skills.SPECIALIZATIONS_TITLE),
-			description: t(Skills.DESCRIPTION_SHORT),
-			author: t(Skills.AUTHOR),
-			createdAt: t(Skills.CREATED_AT),
-		};
-
-		return Object.entries(columns)?.map(([k, v]) => <td key={k}>{v}</td>);
-	};
-
-	const renderTableBody = (skill: Skill) => {
-		const columns = {
-			imageSrc: (
+	const columns: Array<TableColumn<SkillTableRow>> = [
+		{
+			id: 'imageSrc',
+			header: t(Skills.ICON_TITLE_SHORT),
+			width: '10%',
+			cell: ({ row }) => (
 				<ImageWithWrapper
-					src={skill.imageSrc || ''}
-					alt={`${t(Translation.LOGO)} ${skill.title}`}
+					src={row.imageSrc || ''}
+					alt={`${t(Translation.LOGO)} ${row.title}`}
 					className={styles['card-image']}
 				/>
 			),
-			title: (
-				<TableCellLink to={route(ROUTES.admin.skills.detail.page, skill.id)} text={skill.title} />
+		},
+		{
+			id: 'title',
+			header: t(Skills.TITLE_SHORT),
+			width: '10%',
+			cell: ({ row, value }) => (
+				<TableCellLink to={route(ROUTES.admin.skills.details.page, row.id)} text={String(value)} />
 			),
-			specializations: (
+		},
+		{
+			id: 'specializations',
+			header: t(Skills.SPECIALIZATIONS_TITLE),
+			width: '15%',
+			cell: ({ row }) => (
 				<TableCellEntityList
 					url={ROUTES.admin.specializations.details.page}
-					items={skill.specializations}
+					items={row.specializations}
 					showCount={1}
 				/>
 			),
-			description: (
-				<TableCellWithTooltip title={skill.description}>{skill.description}</TableCellWithTooltip>
+		},
+		{
+			id: 'description',
+			header: t(Skills.DESCRIPTION_SHORT),
+			width: 'auto',
+			cell: ({ row }) => (
+				<TableCellWithTooltip title={String(row.description)}>
+					{row.description}
+				</TableCellWithTooltip>
 			),
-			author: skill.createdBy?.username || '-',
-			createdAt: skill.createdAt ? formatDate(new Date(skill.createdAt), 'dd.MM.yyyy') : '',
-		};
+		},
+		{
+			id: 'author',
+			header: t(Skills.AUTHOR),
+			width: '10%',
+		},
+		{
+			id: 'createdAt',
+			header: t(Skills.CREATED_AT),
+			width: '15%',
+			cell: ({ row }) => (
+				<>{row.createdAt ? formatDate(new Date(row.createdAt), 'dd.MM.yyyy') : ''}</>
+			),
+		},
+	];
 
-		return Object.entries(columns)?.map(([k, v]) => <td key={k}>{v}</td>);
-	};
+	const selectedRowIds = selectedSkills?.map((skill) => skill.id);
 
-	const renderActions = (skill: Skill) => {
-		const menuItems: PopoverMenuItem[] = [
-			{
-				icon: <Icon icon="eye" size={24} />,
-				title: t(Translation.SHOW, { ns: i18Namespace.translation }),
-				onClick: () => {
-					navigate(route(ROUTES.admin.skills.detail.page, skill.id));
-				},
-			},
-			{
-				icon: <Icon icon="pen" size={24} />,
-				title: t(Translation.EDIT, { ns: i18Namespace.translation }),
-				onClick: () => {
-					navigate(route(ROUTES.admin.skills.edit.page, skill.id));
-				},
-			},
-			{
-				renderComponent: () => <DeleteSkillButton skillId={skill.id} />,
-			},
-		];
+	const selectedById = useMemo(() => {
+		const byId = new Map<number, { id: number; title?: string }>();
 
-		return (
-			<Flex gap="4">
-				<Popover menuItems={menuItems}>
-					{({ onToggle }) => (
-						<IconButton
-							aria-label="go to details"
-							form="square"
-							icon={<Icon icon="dotsThreeVertical" />}
-							size="medium"
-							variant="tertiary"
-							onClick={onToggle}
-						/>
-					)}
-				</Popover>
-			</Flex>
-		);
-	};
+		selectedSkills?.forEach((skill) => byId.set(skill.id, skill));
+
+		skills?.forEach((skill) => {
+			byId.set(skill.id, { id: skill.id, title: skill.title });
+		});
+
+		return byId;
+	}, [skills, selectedSkills]);
+
+	const onSelectedRowIdsChange = useCallback(
+		(ids: TableRowId[]) => {
+			onSelectSkills?.(ids.map((id) => selectedById.get(id as number) ?? { id: id as number }));
+		},
+		[onSelectSkills, selectedById],
+	);
 
 	if (!skills) {
 		return null;
 	}
 
 	return (
-		<Table
-			renderTableHeader={renderTableHeader}
-			renderTableBody={renderTableBody}
-			renderActions={renderActions}
-			items={skills}
-			selectedItems={selectedSkills}
-			onSelectItems={onSelectSkills}
-			renderTableColumnWidths={renderTableColumnWidths}
-			hasCopyButton
+		<TableV2
+			data={tableData}
+			columns={columns}
+			selectedRowIds={selectedRowIds}
+			onSelectedRowIdsChange={onSelectedRowIdsChange}
+			actions={['detail', 'edit', 'delete', 'copy']}
+			entity="skills"
+			onDelete={(id) => deleteSkill(Number(id))}
 		/>
 	);
 };

--- a/src/shared/config/router/routes.ts
+++ b/src/shared/config/router/routes.ts
@@ -49,7 +49,7 @@ export const ROUTES = {
 				route: ':skillId/edit',
 				page: '/admin/skills/:skillId/edit',
 			},
-			detail: {
+			details: {
 				route: ':skillId',
 				page: '/admin/skills/:skillId',
 			},

--- a/src/widgets/question/GeneratedQuestionsWidget/ui/GeneratedQuestionsTable/GeneratedQuestionsTable.tsx
+++ b/src/widgets/question/GeneratedQuestionsWidget/ui/GeneratedQuestionsTable/GeneratedQuestionsTable.tsx
@@ -114,7 +114,7 @@ export const GeneratedQuestionsTable = ({
 				</td>
 				<td>
 					<TableCellEntityList
-						url={ROUTES.admin.skills.detail.page}
+						url={ROUTES.admin.skills.details.page}
 						items={question.skills}
 						showCount={SKILL_SHOW_COUNT}
 					/>


### PR DESCRIPTION
- Задача: https://tracker.yandex.ru/YH-2388

- Что сделал:
1. Перевел таблицу SkillsTable на TableV2 компонент
2. Переименовал alias ROUTES.admin.skills.detail в ROUTES.admin.skills.details для корректной работы с действиями в новой таблице
3. Обновил роутинг страницы деталей навыка и все найденные ссылки на старый alias в компонентах